### PR TITLE
[feat] 온보딩 완료(툴팁 체크) 여부 DataStore 환경 구축 및 연동 

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,7 +3,6 @@
 plugins {
     alias(libs.plugins.unifest.android.library)
     alias(libs.plugins.unifest.android.hilt)
-    alias(libs.plugins.unifest.android.retrofit)
     id("kotlinx-serialization")
 }
 

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/di/DataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.unifest.android.core.data.di
+
+import com.unifest.android.core.datastore.OnboardingDataSource
+import com.unifest.android.core.datastore.OnboardingDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindOnboardingDataSource(onboardingDataSourceImpl: OnboardingDataSourceImpl): OnboardingDataSource
+}

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import com.unifest.android.core.data.repository.FestivalRepository
 import com.unifest.android.core.data.repository.FestivalRepositoryImpl
 import com.unifest.android.core.data.repository.LikedBoothRepositoryImpl
 import com.unifest.android.core.data.repository.LikedBoothRepository
+import com.unifest.android.core.data.repository.OnboardingRepository
+import com.unifest.android.core.data.repository.OnboardingRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -26,4 +28,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindLikedBoothRepository(likedBoothRepositoryImpl: LikedBoothRepositoryImpl): LikedBoothRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindOnboardingRepository(onboardingRepositoryImpl: OnboardingRepositoryImpl): OnboardingRepository
 }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepository.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepository.kt
@@ -1,0 +1,6 @@
+package com.unifest.android.core.data.repository
+
+interface OnboardingRepository {
+    suspend fun checkOnboardingCompletion(): Boolean
+    suspend fun completeOnboarding(flag: Boolean)
+}

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.unifest.android.core.data.repository
+
+import com.unifest.android.core.datastore.OnboardingDataSource
+import javax.inject.Inject
+
+class OnboardingRepositoryImpl @Inject constructor(
+    private val onboardingDataSource: OnboardingDataSource,
+) : OnboardingRepository {
+
+    override suspend fun checkOnboardingCompletion(): Boolean {
+        return onboardingDataSource.checkOnboardingCompletion()
+    }
+
+    override suspend fun completeOnboarding(flag: Boolean) {
+        onboardingDataSource.completeOnboarding(flag)
+    }
+}

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/MyClass.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/MyClass.kt
@@ -1,3 +1,0 @@
-package com.unifest.android.core.datastore
-
-class MyClass

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSource.kt
@@ -1,0 +1,6 @@
+package com.unifest.android.core.datastore
+
+interface OnboardingDataSource {
+    suspend fun checkOnboardingCompletion(): Boolean
+    suspend fun completeOnboarding(flag: Boolean)
+}

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
@@ -1,0 +1,29 @@
+package com.unifest.android.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+
+class OnboardingDataSourceImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : OnboardingDataSource {
+    private companion object {
+        private val KEY_ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
+    }
+
+    override suspend fun checkOnboardingCompletion(): Boolean = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+            else throw exception
+        }.first()[KEY_ONBOARDING_COMPLETE] ?: false
+
+    override suspend fun completeOnboarding(flag: Boolean) {
+        dataStore.edit { preferences -> preferences[KEY_ONBOARDING_COMPLETE] = flag }
+    }
+}

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreModule.kt
@@ -1,0 +1,24 @@
+package com.unifest.android.core.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val ONBOARDING_DATASTORE = "onboarding_datastore"
+private val Context.onboardingDataStore: DataStore<Preferences> by preferencesDataStore(name = ONBOARDING_DATASTORE)
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object DataStoreModule {
+
+    @Singleton
+    @Provides
+    internal fun provideOnboardingDataStore(@ApplicationContext context: Context) = context.onboardingDataStore
+}

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
@@ -58,6 +58,8 @@ fun UnifestTopAppBar(
     contentColor: Color = Color.Black,
     onNavigationClick: () -> Unit = {},
     onTitleClick: (Boolean) -> Unit = {},
+    isOnboardingCompleted: Boolean = false,
+    completeOnboarding: (Boolean) -> Unit = {},
     elevation: Dp = 0.dp,
 ) {
     CompositionLocalProvider(LocalContentColor provides contentColor) {
@@ -88,10 +90,33 @@ fun UnifestTopAppBar(
                 )
             }
             if (navigationType == TopAppBarNavigationType.Search) {
-                SchoolSearchTitleWithToolTip(
-                    title = title,
-                    onTitleClick = onTitleClick,
-                )
+                if (isOnboardingCompleted) {
+                    Row(
+                        modifier = Modifier
+                            .padding(start = 22.dp, top = 10.dp, bottom = 10.dp, end = 9.dp)
+                            .clickable {
+                                onTitleClick(true)
+                            },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = title,
+                            style = Title1,
+                        )
+                        Spacer(modifier = Modifier.width(7.dp))
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_below),
+                            contentDescription = "Search School",
+                            tint = Color.Unspecified,
+                        )
+                    }
+                } else {
+                    SchoolSearchTitleWithToolTip(
+                        title = title,
+                        onTitleClick = onTitleClick,
+                        completeOnboarding = completeOnboarding,
+                    )
+                }
             } else {
                 Text(
                     text = title,
@@ -115,6 +140,7 @@ fun UnifestTopAppBar(
 fun SchoolSearchTitleWithToolTip(
     title: String,
     onTitleClick: (Boolean) -> Unit,
+    completeOnboarding: (Boolean) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val builder = rememberBalloonBuilder {
@@ -134,7 +160,11 @@ fun SchoolSearchTitleWithToolTip(
         builder = builder,
         balloonContent = {
             Text(
-                modifier = Modifier.wrapContentWidth(),
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .clickable {
+                        completeOnboarding(true)
+                    },
                 text = stringResource(id = R.string.map_school_search_tool_tip_description),
                 textAlign = TextAlign.Center,
                 color = Color.White,
@@ -198,6 +228,7 @@ fun SchoolSearchToolTipPreview() {
         SchoolSearchTitleWithToolTip(
             title = "건국대학교",
             onTitleClick = {},
+            completeOnboarding = {},
         )
     }
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
@@ -166,6 +166,8 @@ fun SchoolSearchTitleWithToolTip(
         setBackgroundColor(Color(0xFFF5687E))
         setBalloonAnimation(BalloonAnimation.FADE)
         setDismissWhenClicked(true)
+        setDismissWhenTouchOutside(false)
+        setFocusable(false)
     }
 
     Balloon(
@@ -189,6 +191,7 @@ fun SchoolSearchTitleWithToolTip(
                 .padding(start = 22.dp, top = 10.dp, bottom = 10.dp, end = 9.dp)
                 .clickable {
                     onTitleClick(true)
+                    completeOnboarding(true)
                 },
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
@@ -147,7 +147,6 @@ fun SchoolSearchTitle(
     }
 }
 
-
 @Composable
 fun SchoolSearchTitleWithToolTip(
     title: String,

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TopAppBar.kt
@@ -91,25 +91,10 @@ fun UnifestTopAppBar(
             }
             if (navigationType == TopAppBarNavigationType.Search) {
                 if (isOnboardingCompleted) {
-                    Row(
-                        modifier = Modifier
-                            .padding(start = 22.dp, top = 10.dp, bottom = 10.dp, end = 9.dp)
-                            .clickable {
-                                onTitleClick(true)
-                            },
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = title,
-                            style = Title1,
-                        )
-                        Spacer(modifier = Modifier.width(7.dp))
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_below),
-                            contentDescription = "Search School",
-                            tint = Color.Unspecified,
-                        )
-                    }
+                    SchoolSearchTitle(
+                        title = title,
+                        onTitleClick = onTitleClick,
+                    )
                 } else {
                     SchoolSearchTitleWithToolTip(
                         title = title,
@@ -135,6 +120,33 @@ fun UnifestTopAppBar(
         }
     }
 }
+
+@Composable
+fun SchoolSearchTitle(
+    title: String,
+    onTitleClick: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(start = 22.dp, top = 10.dp, bottom = 10.dp, end = 9.dp)
+            .clickable {
+                onTitleClick(true)
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = Title1,
+        )
+        Spacer(modifier = Modifier.width(7.dp))
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_below),
+            contentDescription = "Search School",
+            tint = Color.Unspecified,
+        )
+    }
+}
+
 
 @Composable
 fun SchoolSearchTitleWithToolTip(
@@ -212,23 +224,34 @@ fun UnifestTopAppBarPreview() {
 
 @ComponentPreview
 @Composable
-fun UnifestTopAppBarWithBackButtonPreview() {
+fun SchoolSearchTitlePreview() {
     UnifestTheme {
-        UnifestTopAppBar(
-            navigationType = TopAppBarNavigationType.Back,
-            navigationIconContentDescription = "Navigation back icon",
+        SchoolSearchTitle(
+            title = "건국대학교",
+            onTitleClick = {},
         )
     }
 }
 
 @ComponentPreview
 @Composable
-fun SchoolSearchToolTipPreview() {
+fun SchoolSearchTitlePreviewWithTitle() {
     UnifestTheme {
         SchoolSearchTitleWithToolTip(
             title = "건국대학교",
             onTitleClick = {},
             completeOnboarding = {},
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+fun UnifestTopAppBarWithBackButtonPreview() {
+    UnifestTheme {
+        UnifestTopAppBar(
+            navigationType = TopAppBarNavigationType.Back,
+            navigationIconContentDescription = "Navigation back icon",
         )
     }
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -102,6 +102,7 @@ internal fun MapRoute(
         setEnablePopularMode = viewModel::setEnablePopularMode,
         setBoothSelectionMode = viewModel::setBoothSelectionMode,
         updateSelectedBoothList = viewModel::updateSelectedBoothList,
+        completeOnboarding = viewModel::completeOnboarding,
         setLikedFestivalDeleteDialogVisible = viewModel::setLikedFestivalDeleteDialogVisible,
         setServerErrorDialogVisible = viewModel::setServerErrorDialogVisible,
         setNetworkErrorDialogVisible = viewModel::setNetworkErrorDialogVisible,
@@ -125,6 +126,7 @@ internal fun MapScreen(
     setEnableEditMode: () -> Unit,
     setEnablePopularMode: () -> Unit,
     setBoothSelectionMode: (Boolean) -> Unit,
+    completeOnboarding: (Boolean) -> Unit,
     updateSelectedBoothList: (List<BoothDetailMapModel>) -> Unit,
     setLikedFestivalDeleteDialogVisible: (Boolean) -> Unit,
     setServerErrorDialogVisible: (Boolean) -> Unit,
@@ -155,6 +157,7 @@ internal fun MapScreen(
             setEnablePopularMode = setEnablePopularMode,
             setBoothSelectionMode = setBoothSelectionMode,
             updateSelectedBoothList = updateSelectedBoothList,
+            completeOnboarding = completeOnboarding,
             rotationState = rotationState,
         )
 
@@ -209,6 +212,7 @@ fun MapContent(
     setEnablePopularMode: () -> Unit,
     setBoothSelectionMode: (Boolean) -> Unit,
     updateSelectedBoothList: (List<BoothDetailMapModel>) -> Unit,
+    completeOnboarding: (Boolean) -> Unit,
     rotationState: Float,
 ) {
     Box {
@@ -252,13 +256,14 @@ fun MapContent(
                 }
             }
         }
-
         MapTopAppBar(
             title = uiState.selectedSchoolName,
             searchText = uiState.boothSearchText,
             updateSearchText = updateBoothSearchText,
             onTitleClick = setFestivalSearchBottomSheetVisible,
             initSearchText = initSearchText,
+            isOnboardingCompleted = uiState.isOnboardingCompleted,
+            completeOnboarding = completeOnboarding,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.TopCenter),
@@ -325,6 +330,8 @@ fun MapTopAppBar(
     updateSearchText: (TextFieldValue) -> Unit,
     onTitleClick: (Boolean) -> Unit,
     initSearchText: () -> Unit,
+    isOnboardingCompleted: Boolean,
+    completeOnboarding: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -341,6 +348,8 @@ fun MapTopAppBar(
                 navigationType = TopAppBarNavigationType.Search,
                 title = title,
                 onTitleClick = onTitleClick,
+                isOnboardingCompleted = isOnboardingCompleted,
+                completeOnboarding = completeOnboarding,
             )
             SearchTextField(
                 searchText = searchText,
@@ -521,6 +530,7 @@ fun MapScreenPreview() {
             setEnablePopularMode = {},
             setBoothSelectionMode = {},
             updateSelectedBoothList = {},
+            completeOnboarding = {},
             setLikedFestivalDeleteDialogVisible = {},
             setServerErrorDialogVisible = {},
             setNetworkErrorDialogVisible = {},
@@ -538,6 +548,8 @@ fun MapTopAppBarPreview() {
             updateSearchText = {},
             initSearchText = {},
             onTitleClick = {},
+            isOnboardingCompleted = false,
+            completeOnboarding = {},
         )
     }
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -23,6 +23,7 @@ data class MapUiState(
     val isEditMode: Boolean = false,
     val isPopularMode: Boolean = false,
     val isBoothSelectionMode: Boolean = false,
+    val isOnboardingCompleted: Boolean = false,
     val isFestivalSearchBottomSheetVisible: Boolean = false,
     val isLikedFestivalDeleteDialogVisible: Boolean = false,
     val isServerErrorDialogVisible: Boolean = false,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -7,6 +7,7 @@ import com.unifest.android.core.common.ErrorHandlerActions
 import com.unifest.android.core.common.handleException
 import com.unifest.android.core.data.repository.BoothRepository
 import com.unifest.android.core.data.repository.FestivalRepository
+import com.unifest.android.core.data.repository.OnboardingRepository
 import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.feature.map.mapper.toMapModel
@@ -25,6 +26,7 @@ import javax.inject.Inject
 class MapViewModel @Inject constructor(
     private val festivalRepository: FestivalRepository,
     private val boothRepository: BoothRepository,
+    private val onboardingRepository: OnboardingRepository,
 ) : ViewModel(), ErrorHandlerActions {
     private val _uiState = MutableStateFlow(MapUiState())
     val uiState: StateFlow<MapUiState> = _uiState.asStateFlow()
@@ -32,6 +34,7 @@ class MapViewModel @Inject constructor(
     init {
         getAllFestivals()
         getPopularBooths()
+        checkOnboardingCompletion()
 
         val boothList = listOf(
             BoothDetailModel(
@@ -177,6 +180,23 @@ class MapViewModel @Inject constructor(
                 }.onFailure { exception ->
                     handleException(exception, this@MapViewModel)
                 }
+        }
+    }
+
+    private fun checkOnboardingCompletion() {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(isOnboardingCompleted = onboardingRepository.checkOnboardingCompletion())
+            }
+        }
+    }
+
+    fun completeOnboarding(flag: Boolean) {
+        viewModelScope.launch {
+            onboardingRepository.completeOnboarding(flag)
+            _uiState.update {
+                it.copy(isOnboardingCompleted = flag)
+            }
         }
     }
 


### PR DESCRIPTION
툴팁 관련 설정을 추가하였습니다. checkout 해서 정상적으로 동작하는지 확인부탁드립니다. 
dataStore 관련 설정 초기화는 앱 정보 들어가서 데이터 삭제하면 됩니다.

- 툴팁을 누르거나, MapTopAppBar내에 Title(학교명, dropdown arrow)영역을 누를 경우, 툴팁이 사라지고 다시 나타나지 않습니다.
- 툴팁이 떠있을 때, 해당 영역 바깥영역을 눌러도 툴팁이 포커스를 가져가지 않도록 하였습니다.
- 툴팁이 떠있을 때, 해당 영역 바깥을 눌러도 툴팁이 사라지지 않도록 하였습니다. 

---
TODO)
- 학교/축제 내에 툴팁을 추가하여 위와 같은 동작을 지원하도록 구현 