### PR TITLE
[fix] [#79] Snackbar 위치 문제 해결 및 Booth 상세 화면 디자인 디테일 보완 

### DIFF
--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -18,14 +18,20 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -54,13 +60,13 @@ import com.unifest.android.core.model.MenuModel
 import com.unifest.android.core.ui.DevicePreview
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
 import com.unifest.android.feature.booth.viewmodel.BoothViewModel
+import kotlinx.coroutines.launch
 import tech.thdev.compose.exteions.system.ui.controller.rememberExSystemUiController
 
 @Composable
 internal fun BoothDetailRoute(
     padding: PaddingValues,
     onBackClick: () -> Unit,
-    onShowSnackBar: (message: Int) -> Unit,
     onNavigateToBoothLocation: () -> Unit,
     viewModel: BoothViewModel = hiltViewModel(),
 ) {
@@ -90,7 +96,6 @@ internal fun BoothDetailRoute(
         onBookmarkClick = { viewModel.toggleBookmark() },
         isBookmarked = uiState.isBookmarked,
         bookmarkCount = uiState.bookmarkCount,
-        onShowSnackBar = onShowSnackBar,
     )
 }
 
@@ -103,8 +108,11 @@ fun BoothDetailScreen(
     onBookmarkClick: () -> Unit,
     isBookmarked: Boolean,
     bookmarkCount: Int,
-    onShowSnackBar: (message: Int) -> Unit,
 ) {
+    val snackBarState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
     Box(modifier = Modifier.fillMaxSize()) {
         BoothDetailContent(
             uiState = uiState,
@@ -125,10 +133,21 @@ fun BoothDetailScreen(
             bookmarkCount = bookmarkCount,
             onBookmarkClick = {
                 onBookmarkClick()
-                onShowSnackBar(if (isBookmarked) R.string.booth_bookmark_removed_message else R.string.booth_bookmarked_message)
+                scope.launch {
+                    snackBarState.showSnackbar(
+                        message = (if (isBookmarked) context.getString(R.string.booth_bookmark_removed_message) else context.getString(R.string.booth_bookmarked_message)),
+                        duration = SnackbarDuration.Short,
+                    )
+                }
             },
             onWaitingClick = { /*showWaitingDialog = true*/ },
             modifier = Modifier.align(Alignment.BottomCenter),
+        )
+        SnackbarHost(
+            hostState = snackBarState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 116.dp),
         )
     }
 }
@@ -358,7 +377,6 @@ fun BoothScreenPreview() {
             onBookmarkClick = {},
             isBookmarked = false,
             bookmarkCount = 0,
-            onShowSnackBar = {},
         )
     }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -124,7 +124,7 @@ fun BoothDetailScreen(
         BoothDetailContent(
             uiState = uiState,
             onNavigateToBoothLocation = onNavigateToBoothLocation,
-            bottomPadding = padding.calculateBottomPadding(),
+            bottomPadding = 116.dp,
         )
         UnifestTopAppBar(
             navigationType = TopAppBarNavigationType.Back,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -35,6 +37,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,6 +51,7 @@ import com.unifest.android.core.designsystem.component.UnifestButton
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
 import com.unifest.android.core.designsystem.component.UnifestTopAppBar
 import com.unifest.android.core.designsystem.theme.BoothCaution
+import com.unifest.android.core.designsystem.theme.BoothLocation
 import com.unifest.android.core.designsystem.theme.BoothTitle1
 import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.MenuPrice
@@ -60,8 +64,11 @@ import com.unifest.android.core.model.MenuModel
 import com.unifest.android.core.ui.DevicePreview
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
 import com.unifest.android.feature.booth.viewmodel.BoothViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tech.thdev.compose.exteions.system.ui.controller.rememberExSystemUiController
+
+private const val SnackBarDuration = 1000L
 
 @Composable
 internal fun BoothDetailRoute(
@@ -117,7 +124,7 @@ fun BoothDetailScreen(
         BoothDetailContent(
             uiState = uiState,
             onNavigateToBoothLocation = onNavigateToBoothLocation,
-            bottomPadding = 116.dp,
+            bottomPadding = padding.calculateBottomPadding(),
         )
         UnifestTopAppBar(
             navigationType = TopAppBarNavigationType.Back,
@@ -134,10 +141,14 @@ fun BoothDetailScreen(
             onBookmarkClick = {
                 onBookmarkClick()
                 scope.launch {
-                    snackBarState.showSnackbar(
-                        message = (if (isBookmarked) context.getString(R.string.booth_bookmark_removed_message) else context.getString(R.string.booth_bookmarked_message)),
-                        duration = SnackbarDuration.Short,
-                    )
+                    val job = launch {
+                        snackBarState.showSnackbar(
+                            message = (if (isBookmarked) context.getString(R.string.booth_bookmark_removed_message) else context.getString(R.string.booth_bookmarked_message)),
+                            duration = SnackbarDuration.Short,
+                        )
+                    }
+                    delay(SnackBarDuration)
+                    job.cancel()
                 }
             },
             onWaitingClick = { /*showWaitingDialog = true*/ },
@@ -147,7 +158,7 @@ fun BoothDetailScreen(
             hostState = snackBarState,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 116.dp),
+                .padding(bottom = 112.dp),
         )
     }
 }
@@ -176,8 +187,18 @@ fun BoothDetailContent(
                 onNavigateToBoothLocation = onNavigateToBoothLocation,
             )
         }
-        item { Spacer(modifier = Modifier.height(20.dp)) }
+        item { Spacer(modifier = Modifier.height(32.dp)) }
+        item {
+            VerticalDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .background(Color(0xFFF1F3F7)),
+            )
+        }
+        item { Spacer(modifier = Modifier.height(22.dp)) }
         item { MenuText() }
+        item { Spacer(modifier = Modifier.height(16.dp)) }
         items(uiState.boothDetailInfo.menus) { menu -> MenuItem(menu) }
     }
 }
@@ -191,49 +212,54 @@ fun BottomBar(
     modifier: Modifier = Modifier,
 ) {
     val bookMarkColor = if (isBookmarked) Color(0xFFF5687E) else Color(0xFF4B4B4B)
-    Box(
-        modifier = modifier
-            .background(Color.White)
-            .height(116.dp),
+
+    Surface(
+        modifier = modifier.height(116.dp),
+        shadowElevation = 32.dp,
+        color = Color.White,
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+        Box(
+            modifier = Modifier.fillMaxSize()
         ) {
-            Column(
-                modifier = Modifier
-                    .clickable(onClick = onBookmarkClick)
-                    .padding(start = 15.dp, top = 15.dp, end = 15.dp)
-                    .background(Color.Transparent),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(if (isBookmarked) R.drawable.ic_bookmarked else R.drawable.ic_bookmark),
-                    contentDescription = if (isBookmarked) "북마크됨" else "북마크하기",
-                    tint = bookMarkColor,
-                )
-                Spacer(modifier = Modifier.height(1.dp))
-                Text(
-                    text = "$bookmarkCount",
-                    color = bookMarkColor,
-                )
-            }
-            Spacer(modifier = Modifier.width(5.dp))
-            UnifestButton(
-                onClick = onWaitingClick,
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(end = 15.dp),
-                contentPadding = PaddingValues(vertical = 15.dp),
-                enabled = false,
-                containerColor = Color(0xFF777777),
+                    .padding(start = 27.dp, top = 15.dp, end = 15.dp, bottom = 15.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = stringResource(id = R.string.booth_waiting_button_invalid),
-                    style = Title4,
-                    fontSize = 14.sp,
-                )
+                Column(
+                    modifier = Modifier.background(Color.White),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(if (isBookmarked) R.drawable.ic_bookmarked else R.drawable.ic_bookmark),
+                        contentDescription = if (isBookmarked) "북마크됨" else "북마크하기",
+                        tint = bookMarkColor,
+                        modifier = Modifier.clickable {
+                            onBookmarkClick()
+                        }
+                    )
+                    Text(
+                        text = "$bookmarkCount",
+                        color = bookMarkColor,
+                        style = BoothCaution.copy(fontWeight = FontWeight.Bold),
+                    )
+                }
+                Spacer(modifier = Modifier.width(18.dp))
+                UnifestButton(
+                    onClick = onWaitingClick,
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(vertical = 15.dp),
+                    enabled = false,
+                    containerColor = Color(0xFF777777),
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.booth_waiting_button_invalid),
+                        style = Title4,
+                        fontSize = 14.sp,
+                    )
+                }
             }
         }
     }
@@ -241,13 +267,6 @@ fun BottomBar(
 
 @Composable
 fun BoothImage() {
-//    Image(
-//        painter = painterResource(id = R.drawable.booth_image_example),
-//        modifier = Modifier
-//            .height(260.dp)
-//            .fillMaxWidth(),
-//        contentDescription = "Booth Image",
-//    )
     NetworkImage(
         imageUrl = "https://picsum.photos/200/300",
         modifier = Modifier
@@ -269,14 +288,15 @@ fun BoothDescription(
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = name,
+                modifier = Modifier.alignByBaseline(),
                 style = BoothTitle1,
             )
             Spacer(modifier = Modifier.width(5.dp))
             Text(
                 text = category,
+                modifier = Modifier.alignByBaseline(),
                 style = BoothCaution,
                 color = Color(0xFFF5687E),
-                modifier = Modifier.align(Alignment.Bottom),
             )
         }
         Spacer(modifier = Modifier.height(15.dp))
@@ -298,7 +318,8 @@ fun BoothDescription(
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = location,
-                style = Content2,
+                color = Color(0xFF393939),
+                style = BoothLocation,
             )
         }
         Spacer(modifier = Modifier.height(16.dp))

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -143,7 +143,8 @@ fun BoothDetailScreen(
                 scope.launch {
                     val job = launch {
                         snackBarState.showSnackbar(
-                            message = (if (isBookmarked) context.getString(R.string.booth_bookmark_removed_message) else context.getString(R.string.booth_bookmarked_message)),
+                            message = if (isBookmarked) context.getString(R.string.booth_bookmark_removed_message)
+                            else context.getString(R.string.booth_bookmarked_message),
                             duration = SnackbarDuration.Short,
                         )
                     }
@@ -219,7 +220,7 @@ fun BottomBar(
         color = Color.White,
     ) {
         Box(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
         ) {
             Row(
                 modifier = Modifier
@@ -238,7 +239,7 @@ fun BottomBar(
                         tint = bookMarkColor,
                         modifier = Modifier.clickable {
                             onBookmarkClick()
-                        }
+                        },
                     )
                     Text(
                         text = "$bookmarkCount",

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
@@ -34,7 +34,6 @@ fun NavGraphBuilder.boothNavGraph(
     navController: NavHostController,
     onBackClick: () -> Unit,
     onNavigateToBoothLocation: () -> Unit,
-    onShowSnackBar: (Int) -> Unit,
 ) {
     navigation(
         startDestination = BOOTH_DETAIL_ROUTE,
@@ -51,7 +50,6 @@ fun NavGraphBuilder.boothNavGraph(
                 padding = padding,
                 onBackClick = onBackClick,
                 onNavigateToBoothLocation = onNavigateToBoothLocation,
-                onShowSnackBar = onShowSnackBar,
                 viewModel = viewModel,
             )
         }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -75,10 +74,7 @@ internal fun MainScreen(
             )
         },
         snackbarHost = {
-            SnackbarHost(
-                hostState = snackBarHostState,
-                modifier = Modifier.padding(bottom = 64.dp),
-            )
+            SnackbarHost(hostState = snackBarHostState)
         },
         containerColor = White,
     ) { innerPadding ->
@@ -100,7 +96,6 @@ internal fun MainScreen(
                 navController = navigator.navController,
                 onBackClick = navigator::popBackStackIfNotHome,
                 onNavigateToBoothLocation = navigator::navigateToBoothLocation,
-                onShowSnackBar = onShowSnackBar,
             )
             waitingNavGraph(
                 padding = innerPadding,


### PR DESCRIPTION
BoothDetail 화면 내에서는 MainScreen의 Scaffold 내에 SnackBar 를 사용하는 것이 아닌, BoothDetail 내에 Snackbar 를 사용하는 것으로 문제 해결 
  - 해당 화면에서만 특수하게 bottomPadding 을 필요로 하기 때문 
  - Scaffold 를 사용하지 않아도 Snackbar 사용 가능합니다
  - 다른 화면들의 경우 MainScreen 의 Scaffold 내에 Snackbar 사용

BoothDetail 화면 내 디자인 디테일 보완
  - 글자 하단 정렬시 alignByBaseline() 을 통해 같은 라인에 정렬되도록
  - 글씨 폰트 설정, clickable 이벤트 영역 수정
  - bottom bar elevation 설정 
  - 누락된 컴포넌트 추가  
  - [Snackbar 지속시간이 너무 긴거 같아서 조금 줄였습니다](https://velog.io/@mraz3068/Android-Compose-Snackbar-Duration-Custom)