### PR TITLE
[feat] [#75] 최근에 확인한 관심 축제를 저장하기 위한 DataStore 환경 구축

### DIFF
--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
@@ -5,13 +5,14 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import com.unifest.android.core.datastore.di.OnboardingDataStore
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import java.io.IOException
 import javax.inject.Inject
 
 class OnboardingDataSourceImpl @Inject constructor(
-    private val dataStore: DataStore<Preferences>,
+    @OnboardingDataStore private val dataStore: DataStore<Preferences>,
 ) : OnboardingDataSource {
     private companion object {
         private val KEY_ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/RecentLikedFestivalDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/RecentLikedFestivalDataSource.kt
@@ -1,0 +1,6 @@
+package com.unifest.android.core.datastore
+
+interface RecentLikedFestivalDataSource {
+    suspend fun getRecentLikedFestival(): String
+    suspend fun setRecentLikedFestival(schoolName: String)
+}

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/RecentLikedFestivalDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/RecentLikedFestivalDataSourceImpl.kt
@@ -1,0 +1,29 @@
+package com.unifest.android.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+
+class RecentLikedFestivalDataSourceImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : RecentLikedFestivalDataSource {
+    private companion object {
+        private val KEY_RECENT_LIKED_FESTIVAL = stringPreferencesKey("onboarding_complete")
+    }
+
+    override suspend fun getRecentLikedFestival(): String = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+            else throw exception
+        }.first()[KEY_RECENT_LIKED_FESTIVAL] ?: ""
+
+    override suspend fun setRecentLikedFestival(schoolName: String) {
+        dataStore.edit { preferences -> preferences[KEY_RECENT_LIKED_FESTIVAL] = schoolName }
+    }
+}

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreModule.kt
@@ -13,12 +13,20 @@ import javax.inject.Singleton
 
 private const val ONBOARDING_DATASTORE = "onboarding_datastore"
 private val Context.onboardingDataStore: DataStore<Preferences> by preferencesDataStore(name = ONBOARDING_DATASTORE)
+private const val RECENT_FESTIVAL_DATASTORE = "recent_festival_datastore"
+private val Context.recentFestivalDataStore: DataStore<Preferences> by preferencesDataStore(name = RECENT_FESTIVAL_DATASTORE)
 
 @Module
 @InstallIn(SingletonComponent::class)
 internal object DataStoreModule {
 
+    @OnboardingDataStore
     @Singleton
     @Provides
     internal fun provideOnboardingDataStore(@ApplicationContext context: Context) = context.onboardingDataStore
+
+    @RecentFestivalDataStore
+    @Singleton
+    @Provides
+    internal fun provideRecentFestivalDataStore(@ApplicationContext context: Context) = context.recentFestivalDataStore
 }

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreQualifier.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/di/DataStoreQualifier.kt
@@ -1,0 +1,11 @@
+package com.unifest.android.core.datastore.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class OnboardingDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RecentFestivalDataStore


### PR DESCRIPTION
관심 축제가 여러개 있을 경우 그 중에 가장 마지막에 확인한 관심 축제를 화면에 출력하기 위한 DataStore 환경을 구성하였습니다. 
API 를 통해 잘 동작하나 확인까지 해보려했는데 현재 API 에 문제가 있는 것 같아 확인은 못해봤습니다. 