### PR TITLE
[feat] Intro 화면 ScrollableTapRow, HorizontalPager 연동 

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
@@ -87,6 +87,7 @@ fun SearchTextField(
                         Icon(
                             imageVector = ImageVector.vectorResource(R.drawable.ic_search),
                             contentDescription = "Search Icon",
+                            tint = Color.Unspecified,
                             modifier = Modifier.clickable {
                                 onSearch(searchText.text)
                             },

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
         <item>부산/대구</item>
         <item>경상도</item>
     </string-array>
+    <string name="total_festivals_count">총 %d개</string>
 
     <!--    Home    -->
     <string name="home_festival_schedule_text">의 축제 일정</string>

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -1,5 +1,7 @@
 package com.unifest.android.feature.intro
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
@@ -302,10 +304,15 @@ fun AllFestivalsTabRow(
         },
     ) {
         tabTitles.forEachIndexed { index, title ->
+            val isSelected = selectedTabIndex == index
+            val tabTitleColor by animateColorAsState(
+                targetValue = if (isSelected) Color(0xFFF5687E) else Color.Black
+            )
+            val tabTitleFontWeight by animateFloatAsState(
+                targetValue = (if (isSelected) FontWeight.Bold.weight else FontWeight.Normal.weight).toFloat()
+            )
             Tab(
-                selected = selectedTabIndex == index,
-                selectedContentColor = Color(0xFFF5687E),
-                unselectedContentColor = Color.Black,
+                selected = isSelected,
                 onClick = {
                     scope.launch {
                         pagerState.animateScrollToPage(index)
@@ -314,8 +321,9 @@ fun AllFestivalsTabRow(
                 text = {
                     Text(
                         text = title,
+                        color = tabTitleColor,
                         style = Content1,
-                        fontWeight = if (selectedTabIndex == index) FontWeight.Bold else FontWeight.Normal,
+                        fontWeight = FontWeight(weight = tabTitleFontWeight.toInt()),
                     )
                 },
             )

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -290,16 +290,16 @@ fun AllFestivalsTabRow(
 
     ScrollableTabRow(
         selectedTabIndex = selectedTabIndex,
-        contentColor = Color(0xFFE5E5E5),
         containerColor = Color.White,
+        contentColor = Color(0xFFE5E5E5),
         edgePadding = 0.dp,
         indicator = {},
         divider = {
             HorizontalDivider(
                 color = Color(0xFFE5E5E5),
-                thickness = 1.dp,
+                thickness = 1.75.dp,
             )
-        }
+        },
     ) {
         tabTitles.forEachIndexed { index, title ->
             Tab(
@@ -342,7 +342,10 @@ fun AllFestivalsTabRow(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                items(festivals.size) { index ->
+                items(
+                    count = festivals.size,
+                    key = { index -> festivals[index].festivalId },
+                ) { index ->
                     FestivalItem(
                         festival = festivals[index],
                         onFestivalSelected = { festival ->
@@ -423,3 +426,4 @@ fun PreviewIntroScreen() {
         )
     }
 }
+

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -290,76 +290,77 @@ fun AllFestivalsTabRow(
     val scope = rememberCoroutineScope()
     val selectedTabIndex by remember { derivedStateOf { pagerState.currentPage } }
 
-    ScrollableTabRow(
-        selectedTabIndex = selectedTabIndex,
-        containerColor = Color.White,
-        contentColor = Color(0xFFE5E5E5),
-        edgePadding = 0.dp,
-        indicator = {},
-        divider = {
-            HorizontalDivider(
-                color = Color(0xFFE5E5E5),
-                thickness = 1.75.dp,
-            )
-        },
-    ) {
-        tabTitles.forEachIndexed { index, title ->
-            val isSelected = selectedTabIndex == index
-            val tabTitleColor by animateColorAsState(
-                targetValue = if (isSelected) Color(0xFFF5687E) else Color.Black
-            )
-            val tabTitleFontWeight by animateFloatAsState(
-                targetValue = (if (isSelected) FontWeight.Bold.weight else FontWeight.Normal.weight).toFloat()
-            )
-            Tab(
-                selected = isSelected,
-                onClick = {
-                    scope.launch {
-                        pagerState.animateScrollToPage(index)
-                    }
-                },
-                text = {
-                    Text(
-                        text = title,
-                        color = tabTitleColor,
-                        style = Content1,
-                        fontWeight = FontWeight(weight = tabTitleFontWeight.toInt()),
-                    )
-                },
-            )
+    Column {
+        ScrollableTabRow(
+            selectedTabIndex = selectedTabIndex,
+            containerColor = Color.White,
+            contentColor = Color(0xFFE5E5E5),
+            edgePadding = 0.dp,
+            indicator = {},
+            divider = {
+                HorizontalDivider(
+                    color = Color(0xFFE5E5E5),
+                    thickness = 1.75.dp,
+                )
+            },
+        ) {
+            tabTitles.forEachIndexed { index, title ->
+                val isSelected = selectedTabIndex == index
+                val tabTitleColor by animateColorAsState(
+                    targetValue = if (isSelected) Color(0xFFF5687E) else Color.Black,
+                )
+                val tabTitleFontWeight by animateFloatAsState(
+                    targetValue = (if (isSelected) FontWeight.Bold.weight else FontWeight.Normal.weight).toFloat(),
+                )
+                Tab(
+                    selected = isSelected,
+                    onClick = {
+                        scope.launch {
+                            pagerState.animateScrollToPage(index)
+                        }
+                    },
+                    text = {
+                        Text(
+                            text = title,
+                            color = tabTitleColor,
+                            style = Content1,
+                            fontWeight = FontWeight(weight = tabTitleFontWeight.toInt()),
+                        )
+                    },
+                )
+            }
         }
-    }
-
-    HorizontalPager(
-        state = pagerState,
-    ) {
-        Column(modifier = Modifier.padding(top = 8.dp)) {
-            Text(
-                text = "총 ${festivals.size}개",
-                modifier = Modifier
-                    .padding(start = 20.dp, bottom = 16.dp)
-                    .align(Alignment.Start),
-                color = Color(0xFF4C4C4C),
-                style = Content6,
-            )
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                modifier = Modifier
-                    .padding(horizontal = 8.dp)
-                    .height(if (festivals.isEmpty()) 0.dp else (((festivals.size - 1) / 3 + 1) * 140).dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(
-                    count = festivals.size,
-                    key = { index -> festivals[index].festivalId },
-                ) { index ->
-                    FestivalItem(
-                        festival = festivals[index],
-                        onFestivalSelected = { festival ->
-                            onAction(IntroUiAction.OnFestivalSelected(festival))
-                        },
-                    )
+        Text(
+            text = stringResource(id = R.string.total_festivals_count, festivals.size),
+            modifier = Modifier
+                .padding(start = 20.dp, top = 15.dp, bottom = 15.dp)
+                .align(Alignment.Start),
+            color = Color(0xFF4C4C4C),
+            style = Content6,
+        )
+        HorizontalPager(
+            state = pagerState,
+        ) {
+            Column(modifier = Modifier.padding(top = 8.dp)) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .height(if (festivals.isEmpty()) 0.dp else (((festivals.size - 1) / 3 + 1) * 140).dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(
+                        count = festivals.size,
+                        key = { index -> festivals[index].festivalId },
+                    ) { index ->
+                        FestivalItem(
+                            festival = festivals[index],
+                            onFestivalSelected = { festival ->
+                                onAction(IntroUiAction.OnFestivalSelected(festival))
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -132,6 +132,13 @@ fun IntroScreen(
                     selectedFestivals = uiState.selectedFestivals,
                     onAction = onAction,
                 )
+                if (uiState.selectedFestivals.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(21.dp))
+                    HorizontalDivider(
+                        thickness = 7.dp,
+                        color = Color(0xFFEBECF0),
+                    )
+                }
                 AllFestivalsTabRow(
                     festivals = uiState.festivals,
                     onAction = onAction,
@@ -191,19 +198,21 @@ fun LikedFestivalsRow(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp),
         ) {
-            Text(
-                text = stringResource(id = R.string.intro_liked_festivals_title),
-                style = Title3,
-            )
-            TextButton(
-                onClick = { onAction(IntroUiAction.OnClearSelectionClick) },
-            ) {
+            if (selectedFestivals.isNotEmpty()) {
                 Text(
-                    text = stringResource(id = R.string.intro_clear_item_button_text),
-                    color = Color(0xFF848484),
-                    textDecoration = TextDecoration.Underline,
-                    style = Content6,
+                    text = stringResource(id = R.string.intro_liked_festivals_title),
+                    style = Title3,
                 )
+                TextButton(
+                    onClick = { onAction(IntroUiAction.OnClearSelectionClick) },
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.intro_clear_item_button_text),
+                        color = Color(0xFF848484),
+                        textDecoration = TextDecoration.Underline,
+                        style = Content6,
+                    )
+                }
             }
         }
         LazyRow(
@@ -233,7 +242,7 @@ fun FestivalRowItem(
     Card(
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = Color.White, contentColor = Color.Black),
-        border = BorderStroke(1.dp, Color(0xFFD9D9D9)),
+        border = BorderStroke(1.dp, Color(0xFFF5687E)),
         modifier = Modifier
             .height(130.dp)
             .width(120.dp),
@@ -435,4 +444,3 @@ fun PreviewIntroScreen() {
         )
     }
 }
-

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -40,7 +40,7 @@ class MapViewModel @Inject constructor(
     val uiEvent: Flow<MapUiEvent> = _uiEvent.receiveAsFlow()
 
     init {
-        getAllFestivals()
+        // getAllFestivals()
         getPopularBooths()
         checkOnboardingCompletion()
         observeLikedFestivals()


### PR DESCRIPTION
- 아이템 영역을 Swipe 하여도 다음 탭으로 넘어갈 수 있도록 구현
- AllFestivalsTabView -> AllFestivalsTabRow 로 네이밍 변경
- 아이콘 색상 원래 색상에 맞게 보여지도록 수정
- LazyVerticalGrid item 에 대한 key 부여 
- 선택된 Tab 에 대해 글씨의 두께와 색상이 바뀔때, 자연스럽도록 애니메이션 적용

P.S) TabLayout 에 각각의 탭의 Width 를 동적으로 설정하려면 자체 커스텀이 필요할것같습니다. 근데 지금도 전 나쁘지않다고 생각합니다. 
찾아보니 이런 레퍼런스는 있더군요. 정 안되면 참고해서 구현해볼만 한 것 같슴다.
https://medium.com/@gautier.louis/tab-row-made-easy-in-jetpack-compose-8eaa5a602744