### PR TITLE
[feat] [#101] Intro 화면 관심 학교 추가 이후 다시 앱을 켰을 때, 진입되지 않도록 구현  

### DIFF
--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepository.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepository.kt
@@ -1,6 +1,8 @@
 package com.unifest.android.core.data.repository
 
 interface OnboardingRepository {
+    suspend fun checkIntroCompletion(): Boolean
+    suspend fun completeIntro(flag: Boolean)
     suspend fun checkOnboardingCompletion(): Boolean
     suspend fun completeOnboarding(flag: Boolean)
 }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/OnboardingRepositoryImpl.kt
@@ -6,6 +6,13 @@ import javax.inject.Inject
 class OnboardingRepositoryImpl @Inject constructor(
     private val onboardingDataSource: OnboardingDataSource,
 ) : OnboardingRepository {
+    override suspend fun checkIntroCompletion(): Boolean {
+        return onboardingDataSource.checkIntroCompletion()
+    }
+
+    override suspend fun completeIntro(flag: Boolean) {
+        onboardingDataSource.completeIntro(flag)
+    }
 
     override suspend fun checkOnboardingCompletion(): Boolean {
         return onboardingDataSource.checkOnboardingCompletion()

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSource.kt
@@ -1,6 +1,8 @@
 package com.unifest.android.core.datastore
 
 interface OnboardingDataSource {
+    suspend fun checkIntroCompletion(): Boolean
+    suspend fun completeIntro(flag: Boolean)
     suspend fun checkOnboardingCompletion(): Boolean
     suspend fun completeOnboarding(flag: Boolean)
 }

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
@@ -20,10 +20,10 @@ class OnboardingDataSourceImpl @Inject constructor(
     }
 
     override suspend fun checkIntroCompletion(): Boolean = dataStore.data
-    .catch { exception ->
-        if (exception is IOException) emit(emptyPreferences())
-        else throw exception
-    }.first()[KEY_INTRO_COMPLETE] ?: false
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+            else throw exception
+        }.first()[KEY_INTRO_COMPLETE] ?: false
 
     override suspend fun completeIntro(flag: Boolean) {
         dataStore.edit { preferences -> preferences[KEY_INTRO_COMPLETE] = flag }

--- a/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/unifest/android/core/datastore/OnboardingDataSourceImpl.kt
@@ -15,7 +15,18 @@ class OnboardingDataSourceImpl @Inject constructor(
     @OnboardingDataStore private val dataStore: DataStore<Preferences>,
 ) : OnboardingDataSource {
     private companion object {
+        private val KEY_INTRO_COMPLETE = booleanPreferencesKey("intro_complete")
         private val KEY_ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
+    }
+
+    override suspend fun checkIntroCompletion(): Boolean = dataStore.data
+    .catch { exception ->
+        if (exception is IOException) emit(emptyPreferences())
+        else throw exception
+    }.first()[KEY_INTRO_COMPLETE] ?: false
+
+    override suspend fun completeIntro(flag: Boolean) {
+        dataStore.edit { preferences -> preferences[KEY_INTRO_COMPLETE] = flag }
     }
 
     override suspend fun checkOnboardingCompletion(): Boolean = dataStore.data

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementations(
         projects.core.common,
 
+        libs.androidx.splash,
         libs.coil.compose,
         libs.timber,
         libs.ballon.compose,

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/LoadingWheel.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/LoadingWheel.kt
@@ -18,7 +18,7 @@ fun LoadingWheel(
         modifier = modifier.noRippleClickable { },
         contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator(color = Color.Black)
+        CircularProgressIndicator(color = Color(0xFFF5687E))
     }
 }
 

--- a/core/designsystem/src/main/res/values/splash.xml
+++ b/core/designsystem/src/main/res/values/splash.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.Unifest.Splash" parent="Theme.SplashScreen">
+        <item name="postSplashScreenTheme">@style/Theme.Unifest</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+
+</resources>

--- a/feature/intro/src/main/AndroidManifest.xml
+++ b/feature/intro/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
             android:name=".IntroActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Unifest">
+            android:theme="@style/Theme.Unifest.Splash">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroActivity.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.feature.navigator.MainNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,6 +18,7 @@ class IntroActivity : ComponentActivity() {
     lateinit var mainNavigator: MainNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         setContent {
             val systemUiController = rememberExSystemUiController()

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -153,6 +153,7 @@ fun IntroScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 20.dp),
                 contentPadding = PaddingValues(vertical = 17.dp),
+                enabled = uiState.selectedFestivals.isNotEmpty(),
             ) {
                 Text(
                     text = stringResource(id = R.string.intro_add_complete),
@@ -164,7 +165,7 @@ fun IntroScreen(
                 LoadingWheel(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.White)
+                        .background(Color.White),
                 )
             }
         }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -52,6 +53,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.designsystem.R
+import com.unifest.android.core.designsystem.component.LoadingWheel
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.component.SearchTextField
 import com.unifest.android.core.designsystem.component.UnifestButton
@@ -156,6 +158,13 @@ fun IntroScreen(
                     text = stringResource(id = R.string.intro_add_complete),
                     style = Title4,
                     fontSize = 14.sp,
+                )
+            }
+            if (uiState.isLoading) {
+                LoadingWheel(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
                 )
             }
         }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 data class IntroUiState(
+    val isLoading: Boolean = false,
     val searchText: TextFieldValue = TextFieldValue(),
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedFestivals: List<FestivalModel> = emptyList(),

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.data.repository.FestivalRepository
+import com.unifest.android.core.data.repository.OnboardingRepository
 import com.unifest.android.core.model.FestivalModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -19,6 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class IntroViewModel @Inject constructor(
+    private val onboardingRepository: OnboardingRepository,
     private val festivalRepository: FestivalRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(IntroUiState())
@@ -28,66 +30,78 @@ class IntroViewModel @Inject constructor(
     val uiEvent: Flow<IntroUiEvent> = _uiEvent.receiveAsFlow()
 
     init {
-        _uiState.update {
-            it.copy(
-                festivals = persistentListOf(
-                    FestivalModel(
-                        1,
-                        1,
-                        "https://picsum.photos/36",
-                        "서울대학교",
-                        "설대축제",
-                        "05.06",
-                        "05.08",
-                        126.957f,
-                        37.460f,
-                    ),
-                    FestivalModel(
-                        2,
-                        2,
-                        "https://picsum.photos/36",
-                        "연세대학교",
-                        "연대축제",
-                        "05.06",
-                        "05.08",
-                        126.957f,
-                        37.460f,
-                    ),
-                    FestivalModel(
-                        3,
-                        3,
-                        "https://picsum.photos/36",
-                        "고려대학교",
-                        "고대축제",
-                        "05.06",
-                        "05.08",
-                        126.957f,
-                        37.460f,
-                    ),
-                    FestivalModel(
-                        4,
-                        4,
-                        "https://picsum.photos/36",
-                        "성균관대학교",
-                        "성대축제",
-                        "05.06",
-                        "05.08",
-                        126.957f,
-                        37.460f,
-                    ),
-                    FestivalModel(
-                        5,
-                        5,
-                        "https://picsum.photos/36",
-                        "건국대학교",
-                        "건대축제",
-                        "05.06",
-                        "05.08",
-                        126.957f,
-                        37.460f,
-                    ),
-                ),
-            )
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(isLoading = true)
+            }
+            if(onboardingRepository.checkIntroCompletion()) {
+                _uiEvent.send(IntroUiEvent.NavigateToMain)
+            } else {
+                _uiState.update {
+                    it.copy(
+                        festivals = persistentListOf(
+                            FestivalModel(
+                                1,
+                                1,
+                                "https://picsum.photos/36",
+                                "서울대학교",
+                                "설대축제",
+                                "05.06",
+                                "05.08",
+                                126.957f,
+                                37.460f,
+                            ),
+                            FestivalModel(
+                                2,
+                                2,
+                                "https://picsum.photos/36",
+                                "연세대학교",
+                                "연대축제",
+                                "05.06",
+                                "05.08",
+                                126.957f,
+                                37.460f,
+                            ),
+                            FestivalModel(
+                                3,
+                                3,
+                                "https://picsum.photos/36",
+                                "고려대학교",
+                                "고대축제",
+                                "05.06",
+                                "05.08",
+                                126.957f,
+                                37.460f,
+                            ),
+                            FestivalModel(
+                                4,
+                                4,
+                                "https://picsum.photos/36",
+                                "성균관대학교",
+                                "성대축제",
+                                "05.06",
+                                "05.08",
+                                126.957f,
+                                37.460f,
+                            ),
+                            FestivalModel(
+                                5,
+                                5,
+                                "https://picsum.photos/36",
+                                "건국대학교",
+                                "건대축제",
+                                "05.06",
+                                "05.08",
+                                126.957f,
+                                37.460f,
+                            ),
+                        ),
+                    )
+                }
+                _uiState.update {
+                    it.copy(isLoading = false)
+                }
+            }
         }
     }
 
@@ -141,6 +155,7 @@ class IntroViewModel @Inject constructor(
             _uiState.value.selectedFestivals.forEach { festival ->
                 festivalRepository.insertLikedFestivalAtSearch(festival)
             }
+            onboardingRepository.completeIntro(true)
             _uiEvent.send(IntroUiEvent.NavigateToMain)
         }
     }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -34,7 +34,7 @@ class IntroViewModel @Inject constructor(
             _uiState.update {
                 it.copy(isLoading = true)
             }
-            if(onboardingRepository.checkIntroCompletion()) {
+            if (onboardingRepository.checkIntroCompletion()) {
                 _uiEvent.send(IntroUiEvent.NavigateToMain)
             } else {
                 _uiState.update {


### PR DESCRIPTION
- Intro dataStore 환경 구축
- SplashScreen API 연동
- Intro 화면 내에 LoadingWheel 적용 및 색상 변경 
- 관심 축제 추가에 따른 추가완료 버튼 활성화 여부 구현 