### PR TITLE
[feat] [#104] 홈 화면 기능 구현

### DIFF
--- a/core/common/src/main/kotlin/com/unifest/android/core/common/utils/DateUtils.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/utils/DateUtils.kt
@@ -1,0 +1,12 @@
+package com.unifest.android.core.common.utils
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Parses the string as a LocalDate using the provided pattern, defaulting to "yyyy-MM-dd".
+ */
+fun String.toLocalDate(pattern: String = "yyyy-MM-dd"): LocalDate {
+    val dateFormatter = DateTimeFormatter.ofPattern(pattern)
+    return LocalDate.parse(this, dateFormatter)
+}

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalEntityMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalEntityMapper.kt
@@ -36,7 +36,7 @@ internal fun FestivalTodayModel.toEntity(): LikedFestivalEntity {
 internal fun StarInfoModel.toEntity(): StarInfoEntity {
     return StarInfoEntity(
         name = name,
-        img = img,
+        imgUrl = imgUrl,
     )
 }
 

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalMapper.kt
@@ -37,6 +37,6 @@ internal fun FestivalToday.toModel(): FestivalTodayModel {
 internal fun StarInfo.toModel(): StarInfoModel {
     return StarInfoModel(
         name = name,
-        img = img,
+        imgUrl = imgUrl,
     )
 }

--- a/core/database/src/main/kotlin/com/unifest/android/core/database/entity/LikedFestivalEntity.kt
+++ b/core/database/src/main/kotlin/com/unifest/android/core/database/entity/LikedFestivalEntity.kt
@@ -46,5 +46,5 @@ data class LikedFestivalEntity(
 @Serializable
 data class StarInfoEntity(
     val name: String = "",
-    val img: String = "",
+    val imgUrl: String = "",
 )

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/NetworkImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/NetworkImage.kt
@@ -1,19 +1,27 @@
 package com.unifest.android.core.designsystem.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
 import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.theme.Content9
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 
 @Composable
@@ -23,27 +31,51 @@ fun NetworkImage(
     placeholder: Painter? = null,
     contentScale: ContentScale = ContentScale.Crop,
     contentDescription: String? = null,
+    onClick: () -> Unit = {},
+    isClicked: Boolean = false,
+    label: String = "",
+    isClickable: Boolean = true,
 ) {
-    if (LocalInspectionMode.current) {
-        Icon(
-            imageVector = Icons.Outlined.Person,
-            contentDescription = "Example Image Icon",
-            modifier = modifier,
-        )
-    } else {
-        CoilImage(
-            imageModel = { imageUrl },
-            modifier = modifier,
-            component = rememberImageComponent {
-                +PlaceholderPlugin.Loading(placeholder)
-                +PlaceholderPlugin.Failure(placeholder)
-            },
-            imageOptions = ImageOptions(
-                contentScale = contentScale,
-                alignment = Alignment.Center,
-                contentDescription = contentDescription,
-            ),
-        )
+    Box(
+        modifier = modifier
+            .clickable(enabled = isClickable, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (LocalInspectionMode.current) {
+            Icon(
+                imageVector = Icons.Outlined.Person,
+                contentDescription = "Placeholder Image",
+                modifier = Modifier
+                    .size(72.dp)
+                    .align(Alignment.Center),
+            )
+        } else {
+            CoilImage(
+                imageModel = { imageUrl },
+                component = rememberImageComponent {
+                    +PlaceholderPlugin.Loading(placeholder)
+                    +PlaceholderPlugin.Failure(placeholder)
+                },
+                imageOptions = ImageOptions(
+                    contentScale = contentScale,
+                    alignment = Alignment.Center,
+                    contentDescription = contentDescription,
+                ),
+            )
+            if (isClicked && isClickable) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.6f)),
+                )
+                Text(
+                    text = label,
+                    color = Color.White,
+                    style = Content9,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        }
     }
 }
 

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/NetworkImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/NetworkImage.kt
@@ -1,27 +1,19 @@
 package com.unifest.android.core.designsystem.component
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
 import com.unifest.android.core.designsystem.ComponentPreview
-import com.unifest.android.core.designsystem.theme.Content9
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 
 @Composable
@@ -31,51 +23,27 @@ fun NetworkImage(
     placeholder: Painter? = null,
     contentScale: ContentScale = ContentScale.Crop,
     contentDescription: String? = null,
-    onClick: () -> Unit = {},
-    isClicked: Boolean = false,
-    label: String = "",
-    isClickable: Boolean = true,
 ) {
-    Box(
-        modifier = modifier
-            .clickable(enabled = isClickable, onClick = onClick),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (LocalInspectionMode.current) {
-            Icon(
-                imageVector = Icons.Outlined.Person,
-                contentDescription = "Placeholder Image",
-                modifier = Modifier
-                    .size(72.dp)
-                    .align(Alignment.Center),
-            )
-        } else {
-            CoilImage(
-                imageModel = { imageUrl },
-                component = rememberImageComponent {
-                    +PlaceholderPlugin.Loading(placeholder)
-                    +PlaceholderPlugin.Failure(placeholder)
-                },
-                imageOptions = ImageOptions(
-                    contentScale = contentScale,
-                    alignment = Alignment.Center,
-                    contentDescription = contentDescription,
-                ),
-            )
-            if (isClicked && isClickable) {
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(Color.Black.copy(alpha = 0.6f)),
-                )
-                Text(
-                    text = label,
-                    color = Color.White,
-                    style = Content9,
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
-        }
+    if (LocalInspectionMode.current) {
+        Icon(
+            imageVector = Icons.Outlined.Person,
+            contentDescription = "Example Image Icon",
+            modifier = modifier,
+        )
+    } else {
+        CoilImage(
+            imageModel = { imageUrl },
+            modifier = modifier,
+            component = rememberImageComponent {
+                +PlaceholderPlugin.Loading(placeholder)
+                +PlaceholderPlugin.Failure(placeholder)
+            },
+            imageOptions = ImageOptions(
+                contentScale = contentScale,
+                alignment = Alignment.Center,
+                contentDescription = contentDescription,
+            ),
+        )
     }
 }
 

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
@@ -3,10 +3,6 @@ package com.unifest.android.core.designsystem.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Person
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,8 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.Content9
 import com.unifest.android.core.designsystem.theme.UnifestTheme
@@ -23,48 +17,38 @@ import com.unifest.android.core.designsystem.theme.UnifestTheme
 @Composable
 fun StarImage(
     imageUrl: String?,
+    onClick: () -> Unit,
+    isClicked: Boolean,
+    label: String,
     modifier: Modifier = Modifier,
     placeholder: Painter? = null,
     contentScale: ContentScale = ContentScale.Crop,
     contentDescription: String? = null,
-    onClick: () -> Unit = {},
-    isClicked: Boolean = false,
-    label: String = "",
 ) {
     Box(
         modifier = modifier
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        if (LocalInspectionMode.current) {
-            Icon(
-                imageVector = Icons.Outlined.Person,
-                contentDescription = "Placeholder Image",
+        NetworkImage(
+            imageUrl = imageUrl,
+            modifier = Modifier.matchParentSize(),
+            placeholder = placeholder,
+            contentScale = contentScale,
+            contentDescription = contentDescription,
+        )
+        if (isClicked) {
+            Box(
                 modifier = Modifier
-                    .size(72.dp)
-                    .align(Alignment.Center),
+                    .matchParentSize()
+                    .background(Color.Black.copy(alpha = 0.6f)),
             )
-        } else {
-            NetworkImage(
-                imageUrl = imageUrl,
-                modifier = Modifier.matchParentSize(),
-                placeholder = placeholder,
-                contentScale = contentScale,
-                contentDescription = contentDescription,
+            Text(
+                text = label,
+                color = Color.White,
+                style = Content9,
+                modifier = Modifier.align(Alignment.Center),
             )
-            if (isClicked) {
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(Color.Black.copy(alpha = 0.6f)),
-                )
-                Text(
-                    text = label,
-                    color = Color.White,
-                    style = Content9,
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
         }
     }
 }
@@ -73,6 +57,11 @@ fun StarImage(
 @Composable
 fun StarImagePreview() {
     UnifestTheme {
-        StarImage(imageUrl = "")
+        StarImage(
+            imageUrl = "",
+            onClick = {},
+            isClicked = false,
+            label = "",
+        )
     }
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
@@ -1,0 +1,87 @@
+package com.unifest.android.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.coil.CoilImage
+import com.skydoves.landscapist.components.rememberImageComponent
+import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.theme.Content9
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+
+@Composable
+fun StarImage(
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+    placeholder: Painter? = null,
+    contentScale: ContentScale = ContentScale.Crop,
+    contentDescription: String? = null,
+    onClick: () -> Unit = {},
+    isClicked: Boolean = false,
+    label: String = "",
+) {
+    Box(
+        modifier = modifier
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (LocalInspectionMode.current) {
+            Icon(
+                imageVector = Icons.Outlined.Person,
+                contentDescription = "Placeholder Image",
+                modifier = Modifier
+                    .size(72.dp)
+                    .align(Alignment.Center),
+            )
+        } else {
+            CoilImage(
+                imageModel = { imageUrl },
+                component = rememberImageComponent {
+                    +PlaceholderPlugin.Loading(placeholder)
+                    +PlaceholderPlugin.Failure(placeholder)
+                },
+                imageOptions = ImageOptions(
+                    contentScale = contentScale,
+                    alignment = Alignment.Center,
+                    contentDescription = contentDescription,
+                ),
+            )
+            if (isClicked) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.6f)),
+                )
+                Text(
+                    text = label,
+                    color = Color.White,
+                    style = Content9,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+fun StarImagePreview() {
+    UnifestTheme {
+        NetworkImage(imageUrl = "")
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/StarImage.kt
@@ -16,10 +16,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
-import com.skydoves.landscapist.ImageOptions
-import com.skydoves.landscapist.coil.CoilImage
-import com.skydoves.landscapist.components.rememberImageComponent
-import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.Content9
 import com.unifest.android.core.designsystem.theme.UnifestTheme
@@ -49,17 +45,12 @@ fun StarImage(
                     .align(Alignment.Center),
             )
         } else {
-            CoilImage(
-                imageModel = { imageUrl },
-                component = rememberImageComponent {
-                    +PlaceholderPlugin.Loading(placeholder)
-                    +PlaceholderPlugin.Failure(placeholder)
-                },
-                imageOptions = ImageOptions(
-                    contentScale = contentScale,
-                    alignment = Alignment.Center,
-                    contentDescription = contentDescription,
-                ),
+            NetworkImage(
+                imageUrl = imageUrl,
+                modifier = Modifier.matchParentSize(),
+                placeholder = placeholder,
+                contentScale = contentScale,
+                contentDescription = contentDescription,
             )
             if (isClicked) {
                 Box(
@@ -82,6 +73,6 @@ fun StarImage(
 @Composable
 fun StarImagePreview() {
     UnifestTheme {
-        NetworkImage(imageUrl = "")
+        StarImage(imageUrl = "")
     }
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Font.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Font.kt
@@ -151,3 +151,9 @@ val WaitingTeam = TextStyle(
     fontWeight = FontWeight.Bold,
     fontSize = 28.sp,
 )
+
+val Content9 = TextStyle(
+    fontFamily = pretendardFamily,
+    fontWeight = FontWeight.Normal,
+    fontSize = 14.sp,
+)

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/FestivalTodayModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/FestivalTodayModel.kt
@@ -17,5 +17,5 @@ data class FestivalTodayModel(
 @Stable
 data class StarInfoModel(
     val name: String,
-    val img: String,
+    val imgUrl: String,
 )

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/FestivalResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/FestivalResponse.kt
@@ -69,6 +69,6 @@ data class FestivalToday(
 data class StarInfo(
     @SerialName("name")
     val name: String,
-    @SerialName("img")
-    val img: String,
+    @SerialName("imgUrl")
+    val imgUrl: String,
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -54,9 +55,11 @@ import com.kizitonwose.calendar.core.daysOfWeek
 import com.kizitonwose.calendar.core.nextMonth
 import com.kizitonwose.calendar.core.previousMonth
 import com.kizitonwose.calendar.core.yearMonth
+import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.BoothTitle0
 import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.FestivalModel
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -67,6 +70,7 @@ fun Calendar(
     selectedDate: LocalDate,
     onDateSelected: (LocalDate) -> Unit,
     adjacentMonths: Long = 500,
+    allFestivals: List<FestivalModel>,
 ) {
     val currentDate = remember { LocalDate.now() }
     val currentYearMonth = remember(currentDate) { currentDate.yearMonth }
@@ -110,9 +114,11 @@ fun Calendar(
                             day.date,
                             isSelected = isSelectable && selectedDate == day.date,
                             isSelectable = isSelectable,
-                        ) { newSelectedDate ->
-                            onDateSelected(newSelectedDate)
-                        }
+                            onClick = { newSelectedDate ->
+                                onDateSelected(newSelectedDate)
+                            },
+                            allFestivals = allFestivals,
+                        )
                     },
                 )
             }
@@ -125,9 +131,11 @@ fun Calendar(
                             day.date,
                             isSelected = isSelectable && selectedDate == day.date,
                             isSelectable = isSelectable,
-                        ) { newSelectedDate ->
-                            onDateSelected(newSelectedDate)
-                        }
+                            onClick = { newSelectedDate ->
+                                onDateSelected(newSelectedDate)
+                            },
+                            allFestivals = allFestivals,
+                        )
                     },
                 )
             }
@@ -289,26 +297,33 @@ fun Day(
     isSelected: Boolean,
     isSelectable: Boolean,
     onClick: (LocalDate) -> Unit,
+    allFestivals: List<FestivalModel>,
 ) {
     val currentDate = LocalDate.now()
     val isToday = day == currentDate
+    val showFestivalDot = allFestivals.any { festival ->
+        val beginDate = festival.beginDate.toLocalDate()
+        val endDate = festival.endDate.toLocalDate()
+        !(day.isBefore(beginDate) || day.isAfter(endDate))
+    }
 
-    Column {
+    Column(
+        modifier = Modifier.clickable(
+            enabled = isSelectable,
+            showRipple = !isSelected,
+            onClick = { onClick(day) },
+        ),
+    ) {
         Box(
             modifier = Modifier
                 .aspectRatio(1f) // This is important for square-sizing!
-                .padding(12.dp)
+                .padding(10.dp)
                 .clip(CircleShape)
                 .background(color = if (isSelected) Color(0xFFF5687E) else Color.Transparent)
                 .then(
                     if (day == currentDate) {
                         Modifier.border(2.dp, Color(0xFFF5687E), CircleShape)
                     } else Modifier,
-                )
-                .clickable(
-                    enabled = isSelectable,
-                    showRipple = !isSelected,
-                    onClick = { onClick(day) },
                 ),
             contentAlignment = Alignment.Center,
         ) {
@@ -325,6 +340,15 @@ fun Day(
                 fontWeight = FontWeight.Bold,
             )
         }
+        if (showFestivalDot) {
+            Box(
+                modifier = Modifier
+                    .size(7.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF1FC0BA))
+                    .align(Alignment.CenterHorizontally),
+            )
+        }
     }
 }
 
@@ -335,6 +359,7 @@ private fun CalendarPreview() {
         Calendar(
             selectedDate = LocalDate.now(),
             onDateSelected = {},
+            allFestivals = emptyList(),
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -153,6 +155,7 @@ internal fun HomeScreen(
                             onAction = onHomeUiAction,
                             likedFestivals = uiState.likedFestivals,
                             uiState = uiState,
+                            onHomeUiAction = onHomeUiAction,
                         )
                     }
                     if (index < uiState.todayFestivals.size - 1) {
@@ -227,6 +230,7 @@ fun FestivalScheduleItem(
     festival: FestivalTodayModel,
     onAction: (HomeUiAction) -> Unit,
     likedFestivals: List<FestivalModel>,
+    onHomeUiAction: (HomeUiAction) -> Unit,
     uiState: HomeUiState,
 ) {
     Column {
@@ -275,12 +279,22 @@ fun FestivalScheduleItem(
             }
             Spacer(modifier = Modifier.width(39.dp))
             LazyRow {
-                items(festival.starInfo) { starInfo ->
+                itemsIndexed(festival.starInfo) { index, starInfo ->
                     NetworkImage(
                         imageUrl = starInfo.img,
                         modifier = Modifier
                             .size(72.dp)
                             .clip(CircleShape),
+                        onClick = {
+                            if (uiState.starImageClickStates[index] == true) {
+                                onHomeUiAction(HomeUiAction.OnStarImageDismiss(index))
+                            } else {
+                                onHomeUiAction(HomeUiAction.OnStarImageClick(index))
+                            }
+                        },
+                        isClicked = uiState.starImageClickStates[index] ?: false,
+                        label = starInfo.name,
+                        isClickable = true,
                     )
                     Spacer(modifier = Modifier.width(10.dp))
                 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.unifest.android.core.common.FestivalUiAction
 import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.UiText
+import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
@@ -63,6 +64,7 @@ import com.unifest.android.feature.home.viewmodel.HomeViewModel
 import kotlinx.collections.immutable.persistentListOf
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 @Composable
 internal fun HomeRoute(
@@ -150,6 +152,7 @@ internal fun HomeScreen(
                             festival = festival,
                             onAction = onHomeUiAction,
                             likedFestivals = uiState.likedFestivals,
+                            uiState = uiState,
                         )
                     }
                     if (index < uiState.todayFestivals.size - 1) {
@@ -224,6 +227,7 @@ fun FestivalScheduleItem(
     festival: FestivalTodayModel,
     onAction: (HomeUiAction) -> Unit,
     likedFestivals: List<FestivalModel>,
+    uiState: HomeUiState,
 ) {
     Column {
         Row(
@@ -248,7 +252,7 @@ fun FestivalScheduleItem(
                 )
                 Spacer(modifier = Modifier.height(5.dp))
                 Text(
-                    text = festival.festivalName,
+                    text = festival.festivalName + " Day " + ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), uiState.selectedDate),
                     style = Title2,
                 )
                 Spacer(modifier = Modifier.height(7.dp))

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -283,9 +283,6 @@ fun FestivalScheduleItem(
                 itemsIndexed(festival.starInfo) { index, starInfo ->
                     StarImage(
                         imageUrl = starInfo.imgUrl,
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape),
                         onClick = {
                             if (starImageClickStates[index] == true) {
                                 onHomeUiAction(HomeUiAction.OnStarImageDismiss(index))
@@ -295,6 +292,9 @@ fun FestivalScheduleItem(
                         },
                         isClicked = starImageClickStates[index] ?: false,
                         label = starInfo.name,
+                        modifier = Modifier
+                            .size(72.dp)
+                            .clip(CircleShape),
                     )
                     Spacer(modifier = Modifier.width(10.dp))
                 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.component.NetworkImage
+import com.unifest.android.core.designsystem.component.StarImage
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
 import com.unifest.android.core.designsystem.theme.BoothLocation
 import com.unifest.android.core.designsystem.theme.Content4
@@ -278,7 +279,7 @@ fun FestivalScheduleItem(
             Spacer(modifier = Modifier.width(39.dp))
             LazyRow {
                 itemsIndexed(festival.starInfo) { index, starInfo ->
-                    NetworkImage(
+                    StarImage(
                         imageUrl = starInfo.imgUrl,
                         modifier = Modifier
                             .size(72.dp)
@@ -292,7 +293,6 @@ fun FestivalScheduleItem(
                         },
                         isClicked = uiState.starImageClickStates[index] ?: false,
                         label = starInfo.name,
-                        isClickable = true,
                     )
                     Spacer(modifier = Modifier.width(10.dp))
                 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -153,7 +153,8 @@ internal fun HomeScreen(
                             festival = festival,
                             onAction = onHomeUiAction,
                             likedFestivals = uiState.likedFestivals,
-                            uiState = uiState,
+                            selectedDate = uiState.selectedDate,
+                            starImageClickStates = uiState.starImageClickStates,
                             onHomeUiAction = onHomeUiAction,
                         )
                     }
@@ -230,7 +231,8 @@ fun FestivalScheduleItem(
     onAction: (HomeUiAction) -> Unit,
     likedFestivals: List<FestivalModel>,
     onHomeUiAction: (HomeUiAction) -> Unit,
-    uiState: HomeUiState,
+    selectedDate: LocalDate,
+    starImageClickStates: Map<Int, Boolean>,
 ) {
     Column {
         Row(
@@ -255,7 +257,7 @@ fun FestivalScheduleItem(
                 )
                 Spacer(modifier = Modifier.height(5.dp))
                 Text(
-                    text = festival.festivalName + " Day " + ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), uiState.selectedDate),
+                    text = festival.festivalName + " Day " + ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate),
                     style = Title2,
                 )
                 Spacer(modifier = Modifier.height(7.dp))
@@ -285,13 +287,13 @@ fun FestivalScheduleItem(
                             .size(72.dp)
                             .clip(CircleShape),
                         onClick = {
-                            if (uiState.starImageClickStates[index] == true) {
+                            if (starImageClickStates[index] == true) {
                                 onHomeUiAction(HomeUiAction.OnStarImageDismiss(index))
                             } else {
                                 onHomeUiAction(HomeUiAction.OnStarImageClick(index))
                             }
                         },
-                        isClicked = uiState.starImageClickStates[index] ?: false,
+                        isClicked = starImageClickStates[index] ?: false,
                         label = starInfo.name,
                     )
                     Spacer(modifier = Modifier.width(10.dp))

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -103,6 +103,7 @@ internal fun HomeScreen(
                 Calendar(
                     selectedDate = uiState.selectedDate,
                     onDateSelected = { date -> onHomeUiAction(HomeUiAction.OnDateSelected(date)) },
+                    allFestivals = uiState.allFestivals,
                 )
             }
             item {

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -28,8 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -281,7 +279,7 @@ fun FestivalScheduleItem(
             LazyRow {
                 itemsIndexed(festival.starInfo) { index, starInfo ->
                     NetworkImage(
-                        imageUrl = starInfo.img,
+                        imageUrl = starInfo.imgUrl,
                         modifier = Modifier
                             .size(72.dp)
                             .clip(CircleShape),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
@@ -7,4 +7,6 @@ sealed interface HomeUiAction {
     data class OnDateSelected(val date: LocalDate) : HomeUiAction
     data class OnAddAsLikedFestivalClick(val festivalTodayModel: FestivalTodayModel) : HomeUiAction
     data object OnAddLikedFestivalClick : HomeUiAction
+    data class OnStarImageClick(val index: Int) : HomeUiAction
+    data class OnStarImageDismiss(val index: Int) : HomeUiAction
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -28,5 +28,5 @@ data class HomeUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val showAddToFavoritesButton: Boolean = false,
-    val starImageClickStates: Map<Int, Boolean> = emptyMap()
+    val starImageClickStates: Map<Int, Boolean> = emptyMap(),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -4,12 +4,19 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import java.time.LocalDate
 
 data class HomeUiState(
     val incomingFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val todayFestivals: ImmutableList<FestivalTodayModel> = persistentListOf(),
+    val allFestivals: PersistentList<FestivalModel> = persistentListOf(
+        FestivalModel(1, 1, "", "Spring Festival", ",", "2024-04-01", "2024-04-02", 0f, 0f),
+        FestivalModel(2, 2, "", "Spring Festival", ",", "2024-04-04", "2024-04-05", 0f, 0f),
+        FestivalModel(3, 3, "", "Spring Festival", ",", "2024-04-08", "2024-04-10", 0f, 0f),
+    ),
+//    val allFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val festivalSearchText: TextFieldValue = TextFieldValue(),
     val likedFestivals: MutableList<FestivalModel> = mutableListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -28,4 +28,5 @@ data class HomeUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val showAddToFavoritesButton: Boolean = false,
+    val starImageClickStates: Map<Int, Boolean> = emptyMap()
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -146,6 +146,8 @@ class HomeViewModel @Inject constructor(
             is HomeUiAction.OnDateSelected -> setSelectedDate(action.date)
             is HomeUiAction.OnAddAsLikedFestivalClick -> addLikeFestival(action.festivalTodayModel)
             is HomeUiAction.OnAddLikedFestivalClick -> setFestivalSearchBottomSheetVisible(true)
+            is HomeUiAction.OnStarImageClick -> toggleStarImageClicked(action.index, true)
+            is HomeUiAction.OnStarImageDismiss -> toggleStarImageClicked(action.index, false)
         }
     }
 
@@ -299,6 +301,14 @@ class HomeViewModel @Inject constructor(
     private fun deleteLikedFestival(festival: FestivalModel) {
         viewModelScope.launch {
             festivalRepository.deleteLikedFestival(festival)
+        }
+    }
+
+    private fun toggleStarImageClicked(index: Int, isClicked: Boolean) {
+        _uiState.update { currentState ->
+            val newStates = currentState.starImageClickStates.toMutableMap()
+            newStates[index] = isClicked
+            currentState.copy(starImageClickStates = newStates)
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -76,15 +76,15 @@ class HomeViewModel @Inject constructor(
                         starInfo = listOf(
                             StarInfoModel(
                                 name = "비",
-                                img = "https://picsum.photos/36",
+                                imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
                                 name = "싸이",
-                                img = "https://picsum.photos/37",
+                                imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
                                 name = "아이유",
-                                img = "https://picsum.photos/38",
+                                imgUrl = "https://picsum.photos/38",
                             ),
                         ),
                         schoolId = 5,
@@ -99,15 +99,15 @@ class HomeViewModel @Inject constructor(
                         starInfo = listOf(
                             StarInfoModel(
                                 name = "비",
-                                img = "https://picsum.photos/36",
+                                imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
                                 name = "싸이",
-                                img = "https://picsum.photos/37",
+                                imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
                                 name = "아이유",
-                                img = "https://picsum.photos/38",
+                                imgUrl = "https://picsum.photos/38",
                             ),
                         ),
                         schoolId = 1,
@@ -122,15 +122,15 @@ class HomeViewModel @Inject constructor(
                         starInfo = listOf(
                             StarInfoModel(
                                 name = "비",
-                                img = "https://picsum.photos/36",
+                                imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
                                 name = "싸이",
-                                img = "https://picsum.photos/37",
+                                imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
                                 name = "아이유",
-                                img = "https://picsum.photos/38",
+                                imgUrl = "https://picsum.photos/38",
                             ),
                         ),
                         schoolId = 2,

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -39,7 +39,7 @@ class HomeViewModel @Inject constructor(
 
     init {
         observeLikedFestivals()
-
+//        getAllFestivals()
         _uiState.update {
             it.copy(
                 incomingFestivals = persistentListOf(
@@ -226,6 +226,22 @@ class HomeViewModel @Inject constructor(
                 }
         }
     }
+
+//    fun getAllFestivals() {
+//        viewModelScope.launch {
+//            festivalRepository.getAllFestivals()
+//                .onSuccess { festivals ->
+//                    _uiState.update {
+//                        it.copy(
+//                            allFestivals = festivals.toImmutableList(),
+//                        )
+//                    }
+//                }
+//                .onFailure { exception ->
+//                    handleException(exception, this@HomeViewModel)
+//                }
+//        }
+//    }
 
     private fun updateSearchText(text: TextFieldValue) {
         _uiState.update {

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -69,9 +69,9 @@ class HomeViewModel @Inject constructor(
                 todayFestivals = persistentListOf(
                     FestivalTodayModel(
                         festivalId = 5,
-                        beginDate = "5/20(화)",
-                        endDate = "5/22(목)",
-                        festivalName = "녹색지대 DAY 1",
+                        beginDate = "2024-04-05",
+                        endDate = "2024-04-07",
+                        festivalName = "녹색지대",
                         schoolName = "건국대학교",
                         starInfo = listOf(
                             StarInfoModel(
@@ -92,9 +92,9 @@ class HomeViewModel @Inject constructor(
                     ),
                     FestivalTodayModel(
                         festivalId = 1,
-                        beginDate = "5/20(화)",
-                        endDate = "5/22(목)",
-                        festivalName = "녹색지대 DAY 2",
+                        beginDate = "2024-04-15",
+                        endDate = "2024-04-17",
+                        festivalName = "녹색지대",
                         schoolName = "서울대학교",
                         starInfo = listOf(
                             StarInfoModel(
@@ -115,9 +115,9 @@ class HomeViewModel @Inject constructor(
                     ),
                     FestivalTodayModel(
                         festivalId = 2,
-                        beginDate = "5/20(화)",
-                        endDate = "5/22(목)",
-                        festivalName = "녹색지대 DAY 3",
+                        beginDate = "2024-04-22",
+                        endDate = "2024-04-24",
+                        festivalName = "녹색지대",
                         schoolName = "연세대학교",
                         starInfo = listOf(
                             StarInfoModel(


### PR DESCRIPTION
<img width="260" alt="325118457-953d8c49-8e39-4812-acc9-42c6d2ce0ecf" src="https://github.com/Project-Unifest/unifest-android/assets/60922290/d9b81da6-739b-46d9-97a8-a3415ea4f28c">

1. 축제가 있는 날짜에는 청록점이 표시되게 함
2. 축제가 있는 날에는 몇일차인지 계산해서 보이게함(현재는 api가 연결되지 않아 Day 19 이런식으로 보이는데, api를 연결하면 해당날짜에 존재하는 축제만 보일것이므로 문제 없음
3. 연예인 사진 클릭시 어떤 연예인인지 이름 보임 -> 현재는 StarInfoModel에 id가 없어 인덱스 기반으로 상태관리를 작성했는데 같은 name,imgUrl을 사용해서 동시에 이름이 보이고, 사진이 보이는 형태-> 백엔드와 협의해 축제별로 연예인 등록할때 id도 함께 저장하고 내려주게 해볼까 생각중입니다. 아니면 festival Id 별로 또 묶어서 하면되긴하는데 요렇게 해보려다 좀 어려워서 일단은 여기까지 하고 생각을 여쭤보려구요