### PR TITLE
[refactor] [#113] Clustering Library Migration

### DIFF
--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -55,22 +55,20 @@ private const val SnackBarDuration = 1000L
 internal fun MainScreen(
     navigator: MainNavController = rememberMainNavController(),
 ) {
-    val snackBarstate = remember { SnackbarHostState() }
+    val snackBarState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
     val onShowSnackBar: (message: UiText) -> Unit = { message ->
         scope.launch {
-            scope.launch {
-                val job = launch {
-                    snackBarstate.showSnackbar(
-                        message = message.asString(context),
-                        duration = SnackbarDuration.Short,
-                    )
-                }
-                delay(SnackBarDuration)
-                job.cancel()
+            val job = launch {
+                snackBarState.showSnackbar(
+                    message = message.asString(context),
+                    duration = SnackbarDuration.Short,
+                )
             }
+            delay(SnackBarDuration)
+            job.cancel()
         }
     }
 
@@ -84,7 +82,7 @@ internal fun MainScreen(
             )
         },
         snackbarHost = {
-            SnackbarHost(hostState = snackBarstate)
+            SnackbarHost(hostState = snackBarState)
         },
         containerColor = White,
     ) { innerPadding ->

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/model/BoothDetailMapModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/model/BoothDetailMapModel.kt
@@ -1,9 +1,9 @@
 package com.unifest.android.feature.map.model
 
 import android.os.Parcelable
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.clustering.ClusteringKey
 import kotlinx.parcelize.Parcelize
-import ted.gun0912.clustering.clustering.TedClusterItem
-import ted.gun0912.clustering.geometry.TedLatLng
 
 @Parcelize
 data class BoothDetailMapModel(
@@ -16,11 +16,28 @@ data class BoothDetailMapModel(
     val latitude: Double = 0.toDouble(),
     val longitude: Double = 0.toDouble(),
     val menus: List<MenuMapModel> = emptyList(),
-) : Parcelable, TedClusterItem {
-    override fun getTedLatLng(): TedLatLng {
-        return TedLatLng(latitude, longitude)
+) : Parcelable, ClusteringKey {
+    override fun getPosition(): LatLng {
+        return LatLng(latitude, longitude)
     }
 }
+
+//@Parcelize
+//data class BoothDetailMapModel(
+//    val id: Long = 0L,
+//    val name: String = "",
+//    val category: String = "",
+//    val description: String = "",
+//    val warning: String = "",
+//    val location: String = "",
+//    val latitude: Double = 0.toDouble(),
+//    val longitude: Double = 0.toDouble(),
+//    val menus: List<MenuMapModel> = emptyList(),
+//) : Parcelable, TedClusterItem {
+//    override fun getTedLatLng(): TedLatLng {
+//        return TedLatLng(latitude, longitude)
+//    }
+//}
 
 @Parcelize
 data class MenuMapModel(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/model/BoothDetailMapModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/model/BoothDetailMapModel.kt
@@ -22,22 +22,22 @@ data class BoothDetailMapModel(
     }
 }
 
-//@Parcelize
-//data class BoothDetailMapModel(
-//    val id: Long = 0L,
-//    val name: String = "",
-//    val category: String = "",
-//    val description: String = "",
-//    val warning: String = "",
-//    val location: String = "",
-//    val latitude: Double = 0.toDouble(),
-//    val longitude: Double = 0.toDouble(),
-//    val menus: List<MenuMapModel> = emptyList(),
-//) : Parcelable, TedClusterItem {
-//    override fun getTedLatLng(): TedLatLng {
-//        return TedLatLng(latitude, longitude)
-//    }
-//}
+// @Parcelize
+// data class BoothDetailMapModel(
+//     val id: Long = 0L,
+//     val name: String = "",
+//     val category: String = "",
+//     val description: String = "",
+//     val warning: String = "",
+//     val location: String = "",
+//     val latitude: Double = 0.toDouble(),
+//     val longitude: Double = 0.toDouble(),
+//     val menus: List<MenuMapModel> = emptyList(),
+// ) : Parcelable, TedClusterItem {
+//     override fun getTedLatLng(): TedLatLng {
+//         return TedLatLng(latitude, longitude)
+//     }
+// }
 
 @Parcelize
 data class MenuMapModel(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ balloon = "1.6.4"
 calendar-compose = "2.5.0"
 flexible-bottomsheet = "0.1.2"
 
-naver-map-compose = "1.5.5"
+naver-map-compose = "1.5.7"
 naver-map-location = "21.0.1"
 tedclustering-naver = "1.0.2"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://devrepo.kakao.com/nexus/content/groups/public/") }
-        maven("https://naver.jfrog.io/artifactory/maven/")
+        maven("https://repository.map.naver.com/archive/maven")
     }
 }
 


### PR DESCRIPTION
<img width="282" alt="image" src="https://github.com/Project-Unifest/unifest-android/assets/51016231/1b9c697c-92af-4a5a-9d07-d09359766089">

이제 네이버 맵에서 자체적으로 Clustering 을 지원하는 관계로 migration 하였습니다.
제가 관련해서 naver-map-compose 깃허브에 [이슈](https://github.com/fornewid/naver-map-compose/issues/101)를 남겼는데, 성용님께서 바로 배포를 해주셔서 1.5.7버전으로 버전 업데이트후 적용하였습니다.
하지만 아직 어떤 문제가 생길지 모르기 때문에 TedClustering 관련한 의존성과 코드는 제거하지 않고, 주석처리만 해두겠습니다.