### PR TITLE
[Refactor] [#114] MutableList -> PersistentList 로 변경

### DIFF
--- a/core/common/src/main/kotlin/com/unifest/android/core/common/FestivalUiAction.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/FestivalUiAction.kt
@@ -10,6 +10,7 @@ sealed interface FestivalUiAction {
     data object OnTooltipClick : FestivalUiAction
     data class OnEnableSearchMode(val flag: Boolean) : FestivalUiAction
     data object OnEnableEditMode : FestivalUiAction
+    data class OnLikedFestivalSelected(val festival: FestivalModel) : FestivalUiAction
     data class OnAddClick(val festival: FestivalModel) : FestivalUiAction
     data class OnDeleteIconClick(val deleteSelectedFestival: FestivalModel) : FestivalUiAction
     data class OnDialogButtonClick(val type: ButtonType) : FestivalUiAction

--- a/core/common/src/main/kotlin/com/unifest/android/core/common/FestivalUiAction.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/FestivalUiAction.kt
@@ -11,8 +11,8 @@ sealed interface FestivalUiAction {
     data class OnEnableSearchMode(val flag: Boolean) : FestivalUiAction
     data object OnEnableEditMode : FestivalUiAction
     data class OnAddClick(val festival: FestivalModel) : FestivalUiAction
-    data object OnDeleteIconClick : FestivalUiAction
-    data class OnDialogButtonClick(val type: ButtonType, val festival: FestivalModel? = null) : FestivalUiAction
+    data class OnDeleteIconClick(val deleteSelectedFestival: FestivalModel) : FestivalUiAction
+    data class OnDialogButtonClick(val type: ButtonType) : FestivalUiAction
 }
 
 enum class ButtonType {

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
@@ -22,12 +22,9 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,6 +52,7 @@ import com.unifest.android.core.designsystem.theme.Title3
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -64,7 +62,7 @@ import kotlinx.coroutines.launch
 fun FestivalSearchBottomSheet(
     @StringRes searchTextHintRes: Int,
     searchText: TextFieldValue,
-    likedFestivals: MutableList<FestivalModel>,
+    likedFestivals: PersistentList<FestivalModel>,
     festivalSearchResults: ImmutableList<FestivalModel>,
     isSearchMode: Boolean,
     isLikedFestivalDeleteDialogVisible: Boolean,
@@ -73,7 +71,6 @@ fun FestivalSearchBottomSheet(
     isEditMode: Boolean = false,
 ) {
     val selectedFestivals = remember { mutableStateListOf<FestivalModel>() }
-    var deleteSelectedFestival by remember { mutableStateOf<FestivalModel?>(null) }
 //    val bottomSheetState = rememberFlexibleBottomSheetState(
 //        containSystemBars = true,
 //        flexibleSheetSize = FlexibleSheetSize(
@@ -109,7 +106,7 @@ fun FestivalSearchBottomSheet(
                 )
             }
         },
-        windowInsets = WindowInsets(0, 0, 0, 0),
+        windowInsets = WindowInsets(top = 0),
         modifier = Modifier
             .fillMaxHeight()
             .padding(top = 18.dp),
@@ -213,8 +210,7 @@ fun FestivalSearchBottomSheet(
                     },
                     isEditMode = isEditMode,
                     onDeleteLikedFestivalClick = { festival ->
-                        deleteSelectedFestival = festival
-                        onFestivalUiAction(FestivalUiAction.OnDeleteIconClick)
+                        onFestivalUiAction(FestivalUiAction.OnDeleteIconClick(festival))
                     },
                 )
             } else {
@@ -230,7 +226,7 @@ fun FestivalSearchBottomSheet(
                     onFestivalUiAction(FestivalUiAction.OnDialogButtonClick(ButtonType.CANCEL))
                 },
                 onConfirmClick = {
-                    onFestivalUiAction(FestivalUiAction.OnDialogButtonClick(ButtonType.CONFIRM, deleteSelectedFestival))
+                    onFestivalUiAction(FestivalUiAction.OnDialogButtonClick(ButtonType.CONFIRM))
                 },
             )
         }
@@ -244,7 +240,7 @@ fun SchoolSearchBottomSheetPreview() {
         FestivalSearchBottomSheet(
             searchTextHintRes = R.string.festival_search_text_field_hint,
             searchText = TextFieldValue(),
-            likedFestivals = mutableListOf(
+            likedFestivals = persistentListOf(
                 FestivalModel(
                     1,
                     1,

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,7 +68,6 @@ fun FestivalSearchBottomSheet(
     isOnboardingCompleted: Boolean = true,
     isEditMode: Boolean = false,
 ) {
-    val selectedFestivals = remember { mutableStateListOf<FestivalModel>() }
 //    val bottomSheetState = rememberFlexibleBottomSheetState(
 //        containSystemBars = true,
 //        flexibleSheetSize = FlexibleSheetSize(
@@ -206,7 +203,7 @@ fun FestivalSearchBottomSheet(
                 LikedFestivalsGrid(
                     selectedFestivals = likedFestivals,
                     onFestivalSelected = { festival ->
-                        selectedFestivals.remove(festival)
+                        onFestivalUiAction(FestivalUiAction.OnLikedFestivalSelected(festival))
                     },
                     isEditMode = isEditMode,
                     onDeleteLikedFestivalClick = { festival ->

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
@@ -37,14 +37,16 @@ import com.unifest.android.core.designsystem.theme.Content3
 import com.unifest.android.core.designsystem.theme.Content4
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.FestivalModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LikedFestivalsGrid(
-    selectedFestivals: MutableList<FestivalModel>,
+    selectedFestivals: PersistentList<FestivalModel>,
     onFestivalSelected: (FestivalModel) -> Unit,
+    onDeleteLikedFestivalClick: (FestivalModel) -> Unit,
     isEditMode: Boolean = false,
-    onDeleteLikedFestivalClick: (FestivalModel) -> Unit = {},
 ) {
     Column {
         LazyVerticalGrid(
@@ -151,7 +153,7 @@ fun FestivalItem(
 @ComponentPreview
 @Composable
 fun LikedFestivalsGridPreview() {
-    val selectedFestivals = mutableListOf<FestivalModel>()
+    val selectedFestivals = persistentListOf<FestivalModel>()
     repeat(5) {
         selectedFestivals.add(
             FestivalModel(
@@ -169,64 +171,9 @@ fun LikedFestivalsGridPreview() {
     }
     UnifestTheme {
         LikedFestivalsGrid(
-            selectedFestivals = mutableListOf(
-                FestivalModel(
-                    1,
-                    1,
-                    "https://picsum.photos/36",
-                    "서울대학교",
-                    "설대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    2,
-                    2,
-                    "https://picsum.photos/36",
-                    "연세대학교",
-                    "연대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    3,
-                    3,
-                    "https://picsum.photos/36",
-                    "고려대학교",
-                    "고대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    4,
-                    4,
-                    "https://picsum.photos/36",
-                    "성균관대학교",
-                    "성대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    5,
-                    5,
-                    "https://picsum.photos/36",
-                    "건국대학교",
-                    "건대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-            ),
+            selectedFestivals = selectedFestivals,
             onFestivalSelected = {},
+            onDeleteLikedFestivalClick = {},
         )
     }
 }
@@ -234,7 +181,7 @@ fun LikedFestivalsGridPreview() {
 @ComponentPreview
 @Composable
 fun LikedFestivalsGridEditModePreview() {
-    val selectedFestivals = mutableListOf<FestivalModel>()
+    val selectedFestivals = persistentListOf<FestivalModel>()
     repeat(5) {
         selectedFestivals.add(
             FestivalModel(
@@ -252,64 +199,9 @@ fun LikedFestivalsGridEditModePreview() {
     }
     UnifestTheme {
         LikedFestivalsGrid(
-            selectedFestivals = mutableListOf(
-                FestivalModel(
-                    1,
-                    1,
-                    "https://picsum.photos/36",
-                    "서울대학교",
-                    "설대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    2,
-                    2,
-                    "https://picsum.photos/36",
-                    "연세대학교",
-                    "연대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    3,
-                    3,
-                    "https://picsum.photos/36",
-                    "고려대학교",
-                    "고대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    4,
-                    4,
-                    "https://picsum.photos/36",
-                    "성균관대학교",
-                    "성대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-                FestivalModel(
-                    5,
-                    5,
-                    "https://picsum.photos/36",
-                    "건국대학교",
-                    "건대축제",
-                    "05.06",
-                    "05.08",
-                    126.957f,
-                    37.460f,
-                ),
-            ),
+            selectedFestivals = selectedFestivals,
             onFestivalSelected = {},
+            onDeleteLikedFestivalClick = {},
             isEditMode = true,
         )
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -70,6 +70,7 @@ import java.time.temporal.ChronoUnit
 @Composable
 internal fun HomeRoute(
     padding: PaddingValues,
+    popBackStack: () -> Unit,
     onShowSnackBar: (message: UiText) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -77,6 +78,7 @@ internal fun HomeRoute(
 
     ObserveAsEvents(flow = viewModel.uiEvent) { event ->
         when (event) {
+            is HomeUiEvent.NavigateBack -> popBackStack()
             is HomeUiEvent.ShowSnackBar -> onShowSnackBar(event.message)
         }
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
@@ -16,11 +16,13 @@ fun NavController.navigateToHome(navOptions: NavOptions) {
 
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
+    popBackStack: () -> Unit,
     onShowSnackBar: (UiText) -> Unit,
 ) {
     composable(route = HOME_ROUTE) {
         HomeRoute(
             padding = padding,
+            popBackStack = popBackStack,
             onShowSnackBar = onShowSnackBar,
         )
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiEvent.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiEvent.kt
@@ -3,5 +3,6 @@ package com.unifest.android.feature.home.viewmodel
 import com.unifest.android.core.common.UiText
 
 sealed interface HomeUiEvent {
+    data object NavigateBack : HomeUiEvent
     data class ShowSnackBar(val message: UiText) : HomeUiEvent
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -4,22 +4,20 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import java.time.LocalDate
 
 data class HomeUiState(
     val incomingFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val todayFestivals: ImmutableList<FestivalTodayModel> = persistentListOf(),
-    val allFestivals: PersistentList<FestivalModel> = persistentListOf(
-        FestivalModel(1, 1, "", "Spring Festival", ",", "2024-04-01", "2024-04-02", 0f, 0f),
-        FestivalModel(2, 2, "", "Spring Festival", ",", "2024-04-04", "2024-04-05", 0f, 0f),
-        FestivalModel(3, 3, "", "Spring Festival", ",", "2024-04-08", "2024-04-10", 0f, 0f),
-    ),
-//    val allFestivals: ImmutableList<FestivalModel> = persistentListOf(),
+    val allFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val festivalSearchText: TextFieldValue = TextFieldValue(),
-    val likedFestivals: MutableList<FestivalModel> = mutableListOf(),
+    val likedFestivals: PersistentList<FestivalModel> = persistentListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),
+    val deleteSelectedFestival: FestivalModel? = null,
     val isSearchMode: Boolean = false,
     val isEditMode: Boolean = false,
     val isFestivalSearchBottomSheetVisible: Boolean = false,
@@ -28,5 +26,5 @@ data class HomeUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val showAddToFavoritesButton: Boolean = false,
-    val starImageClickStates: Map<Int, Boolean> = emptyMap(),
+    val starImageClickStates: ImmutableMap<Int, Boolean> = persistentMapOf(),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -162,6 +162,7 @@ class HomeViewModel @Inject constructor(
             is FestivalUiAction.OnSearchTextCleared -> clearSearchText()
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
+            is FestivalUiAction.OnLikedFestivalSelected -> setRecentLikedFestival(action.festival.schoolName)
             is FestivalUiAction.OnAddClick -> addLikeFestivalAtBottomSheet(action.festival)
             is FestivalUiAction.OnDeleteIconClick -> {
                 _uiState.update {
@@ -272,6 +273,14 @@ class HomeViewModel @Inject constructor(
     private fun setFestivalSearchBottomSheetVisible(flag: Boolean) {
         _uiState.update {
             it.copy(isFestivalSearchBottomSheetVisible = flag)
+        }
+    }
+
+    private fun setRecentLikedFestival(schoolName: String) {
+        viewModelScope.launch {
+            likedFestivalRepository.setRecentLikedFestival(schoolName)
+            _uiEvent.send(HomeUiEvent.NavigateBack)
+            setLikedFestivalDeleteDialogVisible(false)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -17,6 +17,8 @@ import com.unifest.android.core.model.StarInfoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -161,12 +163,17 @@ class HomeViewModel @Inject constructor(
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
             is FestivalUiAction.OnAddClick -> addLikeFestivalAtBottomSheet(action.festival)
-            is FestivalUiAction.OnDeleteIconClick -> setLikedFestivalDeleteDialogVisible(true)
+            is FestivalUiAction.OnDeleteIconClick -> {
+                _uiState.update {
+                    it.copy(deleteSelectedFestival = action.deleteSelectedFestival)
+                }
+                setLikedFestivalDeleteDialogVisible(true)
+            }
             is FestivalUiAction.OnDialogButtonClick -> {
                 when (action.type) {
                     ButtonType.CONFIRM -> {
                         setLikedFestivalDeleteDialogVisible(false)
-                        action.festival?.let { deleteLikedFestival(it) }
+                        _uiState.value.deleteSelectedFestival?.let { deleteLikedFestival(it) }
                     }
 
                     ButtonType.CANCEL -> setLikedFestivalDeleteDialogVisible(false)
@@ -182,7 +189,7 @@ class HomeViewModel @Inject constructor(
             likedFestivalRepository.getLikedFestivals().collect { likedFestivalList ->
                 _uiState.update {
                     it.copy(
-                        likedFestivals = likedFestivalList.toMutableList(),
+                        likedFestivals = likedFestivalList.toPersistentList(),
                     )
                 }
             }
@@ -314,7 +321,7 @@ class HomeViewModel @Inject constructor(
         _uiState.update { currentState ->
             val newStates = currentState.starImageClickStates.toMutableMap()
             newStates[index] = isClicked
-            currentState.copy(starImageClickStates = newStates)
+            currentState.copy(starImageClickStates = newStates.toImmutableMap())
         }
     }
 }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
@@ -3,11 +3,12 @@ package com.unifest.android.feature.intro.viewmodel
 import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 data class IntroUiState(
     val isLoading: Boolean = false,
     val searchText: TextFieldValue = TextFieldValue(),
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
-    val selectedFestivals: List<FestivalModel> = emptyList(),
+    val selectedFestivals: PersistentList<FestivalModel> = persistentListOf(),
 )

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -130,14 +130,14 @@ class IntroViewModel @Inject constructor(
 
     private fun clearSelectedFestivals() {
         _uiState.update {
-            it.copy(selectedFestivals = emptyList())
+            it.copy(selectedFestivals = persistentListOf())
         }
     }
 
     private fun addSelectedFestival(festival: FestivalModel) {
         _uiState.update {
             it.copy(
-                selectedFestivals = it.selectedFestivals.toMutableList().apply { add(festival) },
+                selectedFestivals = it.selectedFestivals.add(festival),
             )
         }
     }
@@ -145,7 +145,7 @@ class IntroViewModel @Inject constructor(
     private fun removeSelectedFestivals(festival: FestivalModel) {
         _uiState.update {
             it.copy(
-                selectedFestivals = it.selectedFestivals.toMutableList().apply { remove(festival) },
+                selectedFestivals = it.selectedFestivals.remove(festival),
             )
         }
     }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
@@ -65,7 +65,7 @@ internal class MainNavController(
     }
 
     // https://github.com/droidknights/DroidKnights2023_App/pull/243/commits/4bfb6d13908eaaab38ab3a59747d628efa3893cb
-    fun popBackStackIfNotHome() {
+    fun popBackStackIfNotMap() {
         if (!isSameCurrentDestination(MAP_ROUTE)) {
             popBackStack()
         }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -92,6 +92,7 @@ internal fun MainScreen(
         ) {
             homeNavGraph(
                 padding = innerPadding,
+                popBackStack = navigator::popBackStackIfNotMap,
                 onShowSnackBar = onShowSnackBar,
             )
             mapNavGraph(
@@ -101,7 +102,7 @@ internal fun MainScreen(
             boothNavGraph(
                 padding = innerPadding,
                 navController = navigator.navController,
-                popBackStack = navigator::popBackStackIfNotHome,
+                popBackStack = navigator::popBackStackIfNotMap,
                 navigateToBoothLocation = navigator::navigateToBoothLocation,
             )
             waitingNavGraph(
@@ -109,14 +110,15 @@ internal fun MainScreen(
             )
             menuNavGraph(
                 padding = innerPadding,
-                navigateToMap = navigator::popBackStackIfNotHome,
+                popBackStack = navigator::popBackStackIfNotMap,
+                navigateToMap = navigator::popBackStackIfNotMap,
                 navigateToLikedBooth = navigator::navigateToLikedBooth,
                 navigateToBoothDetail = navigator::navigateToBoothDetail,
                 onShowSnackBar = onShowSnackBar,
             )
             likedBoothNavGraph(
                 padding = innerPadding,
-                popBackStack = navigator::popBackStackIfNotHome,
+                popBackStack = navigator::popBackStackIfNotMap,
                 navigateToBoothDetail = navigator::navigateToBoothDetail,
                 onShowSnackBar = onShowSnackBar,
             )

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -1,10 +1,8 @@
 package com.unifest.android.feature.map
 
 import android.Manifest
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -99,7 +97,6 @@ import com.unifest.android.feature.map.viewmodel.MapUiState
 import com.unifest.android.feature.map.viewmodel.MapViewModel
 import kotlinx.collections.immutable.persistentListOf
 
-@RequiresApi(Build.VERSION_CODES.S)
 @Composable
 internal fun MapRoute(
     padding: PaddingValues,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -501,11 +501,11 @@ fun RankingBadge(ranking: Int) {
 @DevicePreview
 @Composable
 fun MapScreenPreview() {
-    val boothList = mutableListOf<BoothDetailMapModel>()
-    repeat(5) {
+    val boothList = persistentListOf<BoothDetailMapModel>()
+    repeat(5) { index ->
         boothList.add(
             BoothDetailMapModel(
-                id = 1L,
+                id = index.toLong(),
                 name = "컴공 주점",
                 category = "",
                 description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
@@ -520,17 +520,7 @@ fun MapScreenPreview() {
             padding = PaddingValues(),
             uiState = MapUiState(
                 selectedSchoolName = "건국대학교",
-                boothList = persistentListOf(
-                    BoothDetailMapModel(
-                        id = 1L,
-                        name = "컴공 주점",
-                        category = "",
-                        description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-                        location = "청심대 앞",
-                        latitude = 37.540470588662664,
-                        longitude = 127.0765263757882,
-                    ),
-                ),
+                boothList = boothList,
             ),
             onMapUiAction = {},
             onFestivalUiAction = {},

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -5,6 +5,7 @@ import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.feature.map.model.BoothDetailMapModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 data class MapUiState(
@@ -16,8 +17,9 @@ data class MapUiState(
     val selectedBoothList: ImmutableList<BoothDetailMapModel> = persistentListOf(),
     val boothSearchText: TextFieldValue = TextFieldValue(),
     val festivalSearchText: TextFieldValue = TextFieldValue(),
-    val likedFestivals: MutableList<FestivalModel> = mutableListOf(),
+    val likedFestivals: PersistentList<FestivalModel> = persistentListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),
+    val deleteSelectedFestival: FestivalModel? = null,
     val isSearchMode: Boolean = false,
     val isEditMode: Boolean = false,
     val isPopularMode: Boolean = false,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -261,6 +261,7 @@ class MapViewModel @Inject constructor(
             is FestivalUiAction.OnSearchTextCleared -> clearFestivalSearchText()
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
+            is FestivalUiAction.OnLikedFestivalSelected -> setRecentLikedFestival(action.festival.schoolName)
             is FestivalUiAction.OnAddClick -> addLikeFestival(action.festival)
             is FestivalUiAction.OnDeleteIconClick -> {
                 _uiState.update {
@@ -385,6 +386,13 @@ class MapViewModel @Inject constructor(
         _uiState.update {
             it.copy(isFestivalSearchBottomSheetVisible = flag)
         }
+    }
+
+    private fun setRecentLikedFestival(schoolName: String) {
+        viewModelScope.launch {
+            likedFestivalRepository.setRecentLikedFestival(schoolName)
+        }
+        setFestivalSearchBottomSheetVisible(false)
     }
 
     private fun addLikeFestival(festival: FestivalModel) {

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -18,6 +18,7 @@ import com.unifest.android.feature.map.model.BoothDetailMapModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -261,12 +262,17 @@ class MapViewModel @Inject constructor(
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
             is FestivalUiAction.OnAddClick -> addLikeFestival(action.festival)
-            is FestivalUiAction.OnDeleteIconClick -> setLikedFestivalDeleteDialogVisible(true)
+            is FestivalUiAction.OnDeleteIconClick -> {
+                _uiState.update {
+                    it.copy(deleteSelectedFestival = action.deleteSelectedFestival)
+                }
+                setLikedFestivalDeleteDialogVisible(true)
+            }
             is FestivalUiAction.OnDialogButtonClick -> {
                 when (action.type) {
                     ButtonType.CONFIRM -> {
                         setLikedFestivalDeleteDialogVisible(false)
-                        action.festival?.let { deleteLikedFestival(it) }
+                        _uiState.value.deleteSelectedFestival?.let { deleteLikedFestival(it) }
                     }
 
                     ButtonType.CANCEL -> setLikedFestivalDeleteDialogVisible(false)
@@ -281,7 +287,7 @@ class MapViewModel @Inject constructor(
             likedFestivalRepository.getLikedFestivals().collect { likedFestivalList ->
                 _uiState.update {
                     it.copy(
-                        likedFestivals = likedFestivalList.toMutableList(),
+                        likedFestivals = likedFestivalList.toPersistentList(),
                     )
                 }
             }

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/MenuScreen.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/MenuScreen.kt
@@ -75,6 +75,7 @@ import timber.log.Timber
 @Composable
 internal fun MenuRoute(
     padding: PaddingValues,
+    popBackStack: () -> Unit,
     navigateToMap: () -> Unit,
     navigateToLikedBooth: () -> Unit,
     navigateToBoothDetail: (Long) -> Unit,
@@ -95,6 +96,7 @@ internal fun MenuRoute(
 
     ObserveAsEvents(flow = viewModel.uiEvent) { event ->
         when (event) {
+            is MenuUiEvent.NavigateBack -> popBackStack()
             is MenuUiEvent.NavigateToMap -> navigateToMap()
             is MenuUiEvent.NavigateToLikedBooth -> navigateToLikedBooth()
             is MenuUiEvent.NavigateToBoothDetail -> navigateToBoothDetail(event.boothId)

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/navigation/MenuNavigation.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/navigation/MenuNavigation.kt
@@ -16,6 +16,7 @@ fun NavController.navigateToMenu(navOptions: NavOptions) {
 
 fun NavGraphBuilder.menuNavGraph(
     padding: PaddingValues,
+    popBackStack: () -> Unit,
     navigateToMap: () -> Unit,
     navigateToLikedBooth: () -> Unit,
     navigateToBoothDetail: (Long) -> Unit,
@@ -24,6 +25,7 @@ fun NavGraphBuilder.menuNavGraph(
     composable(route = MENU_ROUTE) {
         MenuRoute(
             padding = padding,
+            popBackStack = popBackStack,
             navigateToMap = navigateToMap,
             navigateToLikedBooth = navigateToLikedBooth,
             navigateToBoothDetail = navigateToBoothDetail,

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuUiEvent.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuUiEvent.kt
@@ -3,6 +3,7 @@ package com.unifest.android.feature.menu.viewmodel
 import com.unifest.android.core.common.UiText
 
 sealed interface MenuUiEvent {
+    data object NavigateBack : MenuUiEvent
     data object NavigateToMap : MenuUiEvent
     data object NavigateToLikedBooth : MenuUiEvent
     data class NavigateToBoothDetail(val boothId: Long) : MenuUiEvent

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuUiState.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuUiState.kt
@@ -4,14 +4,16 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 data class MenuUiState(
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
     val likedBoothList: ImmutableList<BoothDetailModel> = persistentListOf(),
     val festivalSearchText: TextFieldValue = TextFieldValue(),
-    val likedFestivals: MutableList<FestivalModel> = mutableListOf(),
+    val likedFestivals: PersistentList<FestivalModel> = persistentListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),
+    val deleteSelectedFestival: FestivalModel? = null,
     val isSearchMode: Boolean = false,
     val isEditMode: Boolean = false,
     val isFestivalSearchBottomSheetVisible: Boolean = false,

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -13,6 +13,7 @@ import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.FestivalModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -65,12 +66,17 @@ class MenuViewModel @Inject constructor(
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
             is FestivalUiAction.OnAddClick -> addLikeFestival(action.festival)
-            is FestivalUiAction.OnDeleteIconClick -> setLikedFestivalDeleteDialogVisible(true)
+            is FestivalUiAction.OnDeleteIconClick -> {
+                _uiState.update {
+                    it.copy(deleteSelectedFestival = action.deleteSelectedFestival)
+                }
+                setLikedFestivalDeleteDialogVisible(true)
+            }
             is FestivalUiAction.OnDialogButtonClick -> {
                 when (action.type) {
                     ButtonType.CONFIRM -> {
                         setLikedFestivalDeleteDialogVisible(false)
-                        action.festival?.let { deleteLikedFestival(it) }
+                        _uiState.value.deleteSelectedFestival?.let { deleteLikedFestival(it) }
                     }
 
                     ButtonType.CANCEL -> setLikedFestivalDeleteDialogVisible(false)
@@ -86,7 +92,7 @@ class MenuViewModel @Inject constructor(
             likedFestivalRepository.getLikedFestivals().collect { likedFestivalList ->
                 _uiState.update {
                     it.copy(
-                        likedFestivals = likedFestivalList.toMutableList(),
+                        likedFestivals = likedFestivalList.toPersistentList(),
                     )
                 }
             }

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -43,12 +43,7 @@ class MenuViewModel @Inject constructor(
 
     fun onMenuUiAction(action: MenuUiAction) {
         when (action) {
-            is MenuUiAction.OnLikedFestivalItemClick -> {
-                viewModelScope.launch {
-                    likedFestivalRepository.setRecentLikedFestival(action.schoolName)
-                    _uiEvent.send(MenuUiEvent.NavigateToMap)
-                }
-            }
+            is MenuUiAction.OnLikedFestivalItemClick -> navigateToMap(action.schoolName)
             is MenuUiAction.OnAddClick -> setFestivalSearchBottomSheetVisible(true)
             is MenuUiAction.OnLikedBoothItemClick -> navigateToBoothDetail(action.boothId)
             is MenuUiAction.OnToggleBookmark -> deleteLikedBooth(action.booth)
@@ -65,6 +60,10 @@ class MenuViewModel @Inject constructor(
             is FestivalUiAction.OnSearchTextCleared -> clearSearchText()
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
+            is FestivalUiAction.OnLikedFestivalSelected -> {
+                setLikedFestivalDeleteDialogVisible(false)
+                navigateToMap(action.festival.schoolName)
+            }
             is FestivalUiAction.OnAddClick -> addLikeFestival(action.festival)
             is FestivalUiAction.OnDeleteIconClick -> {
                 _uiState.update {
@@ -108,6 +107,13 @@ class MenuViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun navigateToMap(schoolName: String,) {
+        viewModelScope.launch {
+            likedFestivalRepository.setRecentLikedFestival(schoolName)
+            _uiEvent.send(MenuUiEvent.NavigateToMap)
         }
     }
 

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -110,7 +110,7 @@ class MenuViewModel @Inject constructor(
         }
     }
 
-    private fun navigateToMap(schoolName: String,) {
+    private fun navigateToMap(schoolName: String) {
         viewModelScope.launch {
             likedFestivalRepository.setRecentLikedFestival(schoolName)
             _uiEvent.send(MenuUiEvent.NavigateToMap)


### PR DESCRIPTION
MutableList 또는 List 가 컴포저블 함수의 파라미터로 존재할 경우, 해당 컴포저블 함수는 Stable 판정을 받지 못하여, Unstable 하게 됩니다.
그렇게 되면, 변경 사항이 없어도 recomposition 을 skip 하지 못하고, 매번 recomposition이 수행됩니다. (성능 저하의 원인)

- 따라서 변경 가능성이 있늠 목록을 관리하는 자료구조인 MutableList 를 사용하는 곳들(UiState)의 
파라미터를 persistentList 로 타입을 변경하였습니다. 

- 컴포저블 함수 내에 state 를 제거하여, stateless 하게 변경해주었습니다.

그외)
축제 바텀시트 내에 관심 축제 아이템을 클릭했을 경우에 대한 클릭 이벤트를 구현해주었습니다.
(최근 선택된 관심 축제 변경 -> 바텀시트 닫기 -> 맵화면으로 이동 -> 맵 화면에서는 최근 선택된 관심 축제를 구독하여, 최신 변경 사항을 반영해야함(todo))