### PR TITLE
[feat] [#123] [#121] 홈 화면 이슈 해결  및 코드 개선 

### DIFF
--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/FestivalMapper.kt
@@ -36,6 +36,7 @@ internal fun FestivalToday.toModel(): FestivalTodayModel {
 
 internal fun StarInfo.toModel(): StarInfoModel {
     return StarInfoModel(
+        starId = starId,
         name = name,
         imgUrl = imgUrl,
     )

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/FestivalTodayModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/FestivalTodayModel.kt
@@ -16,6 +16,7 @@ data class FestivalTodayModel(
 
 @Stable
 data class StarInfoModel(
+    val starId: Long,
     val name: String,
     val imgUrl: String,
 )

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/FestivalResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/FestivalResponse.kt
@@ -67,6 +67,8 @@ data class FestivalToday(
 
 @Serializable
 data class StarInfo(
+    @SerialName("starId")
+    val starId: Long,
     @SerialName("name")
     val name: String,
     @SerialName("imgUrl")

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.unifest.android.feature.booth
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -47,9 +45,9 @@ import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.component.TopAppBarNavigationType
 import com.unifest.android.core.designsystem.component.UnifestButton
+import com.unifest.android.core.designsystem.component.UnifestHorizontalDivider
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
 import com.unifest.android.core.designsystem.component.UnifestTopAppBar
-import com.unifest.android.core.designsystem.component.UnifestHorizontalDivider
 import com.unifest.android.core.designsystem.theme.BoothCaution
 import com.unifest.android.core.designsystem.theme.BoothLocation
 import com.unifest.android.core.designsystem.theme.BoothTitle1
@@ -336,8 +334,8 @@ fun MenuItem(menu: MenuModel) {
     Row(
         modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.booth_menu_image_example),
+        NetworkImage(
+            imageUrl = "https://picsum.photos/80",
             contentDescription = menu.name,
             modifier = Modifier.size(88.dp),
         )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -32,10 +32,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -85,8 +86,7 @@ fun Calendar(
         modifier = Modifier.shadow(4.dp, RoundedCornerShape(bottomEnd = 20.dp, bottomStart = 20.dp)),
     ) {
         Column(
-            modifier = Modifier
-                .background(Color.White),
+            modifier = Modifier.background(Color.White),
         ) {
             val monthState = rememberCalendarState(
                 startMonth = startMonth,
@@ -157,15 +157,14 @@ fun ModeToggleButton(
     isWeekMode: Boolean,
     onModeChange: (Boolean) -> Unit,
 ) {
-    val icon = if (isWeekMode) painterResource(id = R.drawable.ic_calender_down) else painterResource(id = R.drawable.ic_calender_up)
-    val contentDescription = if (isWeekMode) "Month" else "Week"
-    val backgroundPainter = painterResource(id = R.drawable.calender_bottom)
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .requiredHeight(40.dp)
-            .paint(painter = backgroundPainter, contentScale = ContentScale.FillBounds)
+            .paint(
+                painter = painterResource(id = R.drawable.calender_bottom),
+                contentScale = ContentScale.FillBounds,
+            )
             .then(modifier),
         contentAlignment = Alignment.Center,
     ) {
@@ -173,8 +172,9 @@ fun ModeToggleButton(
             onClick = { onModeChange(!isWeekMode) },
         ) {
             Icon(
-                painter = icon,
-                contentDescription = contentDescription,
+                imageVector = if (isWeekMode) ImageVector.vectorResource(id = R.drawable.ic_calender_down)
+                else ImageVector.vectorResource(id = R.drawable.ic_calender_up),
+                contentDescription = if (isWeekMode) "Month" else "Week",
                 tint = Color(0xFFD9D9D9),
             )
         }
@@ -183,7 +183,7 @@ fun ModeToggleButton(
 
 @Composable
 private fun CalendarNavigationIcon(
-    icon: Painter,
+    icon: ImageVector,
     contentDescription: String,
     onClick: () -> Unit,
 ) = Box(
@@ -198,7 +198,7 @@ private fun CalendarNavigationIcon(
             .fillMaxSize()
             .padding(4.dp)
             .align(Alignment.Center),
-        painter = icon,
+        imageVector = icon,
         contentDescription = contentDescription,
         tint = Color.Gray,
     )
@@ -247,10 +247,10 @@ fun MonthAndWeekCalendarTitle(
 @Composable
 fun SimpleCalendarTitle(
     // 실제로 달력의 상단에 현재 월을 표시하고, 이전/다음 월로 이동할 수 있는 화살표 아이콘을 제공하는 UI 컴포넌트
-    modifier: Modifier,
     currentMonth: Month,
     goToPrevious: () -> Unit,
     goToNext: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier.height(40.dp),
@@ -263,12 +263,12 @@ fun SimpleCalendarTitle(
             textAlign = TextAlign.Start,
         )
         CalendarNavigationIcon(
-            icon = painterResource(id = R.drawable.ic_chevron_left),
+            icon = ImageVector.vectorResource(id = R.drawable.ic_chevron_left),
             contentDescription = "Previous",
             onClick = goToPrevious,
         )
         CalendarNavigationIcon(
-            icon = painterResource(id = R.drawable.ic_chevron_right),
+            icon = ImageVector.vectorResource(id = R.drawable.ic_chevron_right),
             contentDescription = "Next",
             onClick = goToNext,
         )
@@ -299,8 +299,8 @@ fun Day(
     day: LocalDate,
     isSelected: Boolean,
     isSelectable: Boolean,
-    onClick: (LocalDate) -> Unit,
     allFestivals: ImmutableList<FestivalModel>,
+    onClick: (LocalDate) -> Unit,
 ) {
     val currentDate = LocalDate.now()
     val isToday = day == currentDate

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -155,7 +155,6 @@ internal fun HomeScreen(
                         Spacer(modifier = Modifier.height(16.dp))
                         FestivalScheduleItem(
                             festival = festival,
-                            onAction = onHomeUiAction,
                             likedFestivals = uiState.likedFestivals,
                             selectedDate = uiState.selectedDate,
                             starImageClickStates = uiState.starImageClickStates,
@@ -167,7 +166,6 @@ internal fun HomeScreen(
                         HorizontalDivider(
                             color = Color(0xFFDFDFDF),
                             modifier = Modifier.padding(horizontal = 20.dp),
-                            thickness = 1.dp,
                         )
                     }
                 }
@@ -223,11 +221,10 @@ fun FestivalScheduleText(selectedDate: LocalDate) {
 @Composable
 fun FestivalScheduleItem(
     festival: FestivalTodayModel,
-    onAction: (HomeUiAction) -> Unit,
     likedFestivals: ImmutableList<FestivalModel>,
-    onHomeUiAction: (HomeUiAction) -> Unit,
     selectedDate: LocalDate,
     starImageClickStates: Map<Int, Boolean>,
+    onHomeUiAction: (HomeUiAction) -> Unit,
 ) {
     Column {
         Row(
@@ -298,7 +295,7 @@ fun FestivalScheduleItem(
         if (!likedFestivals.any { it.festivalId == festival.festivalId }) {
             UnifestOutlinedButton(
                 onClick = {
-                    onAction(HomeUiAction.OnAddAsLikedFestivalClick(festival))
+                    onHomeUiAction(HomeUiAction.OnAddAsLikedFestivalClick(festival))
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -150,18 +150,19 @@ internal fun HomeScreen(
                 itemsIndexed(
                     items = uiState.todayFestivals,
                     key = { _, festival -> festival.festivalId },
-                ) { index, festival ->
+                ) { scheduleIndex, festival ->
                     Column {
                         Spacer(modifier = Modifier.height(16.dp))
                         FestivalScheduleItem(
                             festival = festival,
+                            scheduleIndex = scheduleIndex,
                             likedFestivals = uiState.likedFestivals,
                             selectedDate = uiState.selectedDate,
-                            starImageClickStates = uiState.starImageClickStates,
+                            isStarImageClicked = uiState.isStarImageClicked[scheduleIndex],
                             onHomeUiAction = onHomeUiAction,
                         )
                     }
-                    if (index < uiState.todayFestivals.size - 1) {
+                    if (scheduleIndex < uiState.todayFestivals.size - 1) {
                         Spacer(modifier = Modifier.height(16.dp))
                         HorizontalDivider(
                             color = Color(0xFFDFDFDF),
@@ -188,9 +189,11 @@ internal fun HomeScreen(
             item { UnifestHorizontalDivider() }
             item { Spacer(modifier = Modifier.height(20.dp)) }
             item { IncomingFestivalText() }
-            items(uiState.incomingFestivals) { festival ->
-                IncomingFestivalCard(festival)
-                Spacer(modifier = Modifier.height(8.dp))
+            if (uiState.incomingFestivals.isNotEmpty()) {
+                items(uiState.incomingFestivals) { festival ->
+                    IncomingFestivalCard(festival)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
         if (uiState.isFestivalSearchBottomSheetVisible) {
@@ -221,9 +224,10 @@ fun FestivalScheduleText(selectedDate: LocalDate) {
 @Composable
 fun FestivalScheduleItem(
     festival: FestivalTodayModel,
+    scheduleIndex: Int,
     likedFestivals: ImmutableList<FestivalModel>,
     selectedDate: LocalDate,
-    starImageClickStates: Map<Int, Boolean>,
+    isStarImageClicked: ImmutableList<Boolean>,
     onHomeUiAction: (HomeUiAction) -> Unit,
 ) {
     Column {
@@ -271,24 +275,25 @@ fun FestivalScheduleItem(
                 }
             }
             Spacer(modifier = Modifier.width(39.dp))
-            LazyRow {
-                itemsIndexed(festival.starInfo) { index, starInfo ->
-                    StarImage(
-                        imageUrl = starInfo.imgUrl,
-                        onClick = {
-                            if (starImageClickStates[index] == true) {
-                                onHomeUiAction(HomeUiAction.OnStarImageDismiss(index))
-                            } else {
-                                onHomeUiAction(HomeUiAction.OnStarImageClick(index))
-                            }
-                        },
-                        isClicked = starImageClickStates[index] ?: false,
-                        label = starInfo.name,
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape),
-                    )
-                    Spacer(modifier = Modifier.width(10.dp))
+            if (festival.starInfo.isNotEmpty()) {
+                LazyRow {
+                    itemsIndexed(
+                        items = festival.starInfo,
+                        key = { _, starInfo -> starInfo.starId },
+                    ) { starIndex, starInfo ->
+                        StarImage(
+                            imageUrl = starInfo.imgUrl,
+                            onClick = {
+                                onHomeUiAction(HomeUiAction.OnToggleStarImageClick(scheduleIndex, starIndex, !isStarImageClicked[starIndex]))
+                            },
+                            isClicked = isStarImageClicked[starIndex],
+                            label = starInfo.name,
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(CircleShape),
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                    }
                 }
             }
         }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -245,7 +246,9 @@ fun FestivalScheduleItem(
                     .align(Alignment.CenterVertically),
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Column {
+            Column(
+                modifier = Modifier.width(172.dp),
+            ) {
                 Text(
                     text = "${festival.beginDate.toLocalDate().formatWithDayOfWeek()} - ${festival.endDate.toLocalDate().formatWithDayOfWeek()}",
                     style = Content4,
@@ -254,6 +257,8 @@ fun FestivalScheduleItem(
                 Spacer(modifier = Modifier.height(5.dp))
                 Text(
                     text = festival.festivalName + " Day " + ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     style = Title2,
                 )
                 Spacer(modifier = Modifier.height(7.dp))
@@ -274,7 +279,6 @@ fun FestivalScheduleItem(
                     )
                 }
             }
-            Spacer(modifier = Modifier.width(39.dp))
             if (festival.starInfo.isNotEmpty()) {
                 LazyRow {
                     itemsIndexed(

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
@@ -7,6 +7,5 @@ sealed interface HomeUiAction {
     data class OnDateSelected(val date: LocalDate) : HomeUiAction
     data class OnAddAsLikedFestivalClick(val festivalTodayModel: FestivalTodayModel) : HomeUiAction
     data object OnAddLikedFestivalClick : HomeUiAction
-    data class OnStarImageClick(val index: Int) : HomeUiAction
-    data class OnStarImageDismiss(val index: Int) : HomeUiAction
+    data class OnToggleStarImageClick(val scheduleIndex: Int, val starIndex: Int, val flag: Boolean) : HomeUiAction
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -4,9 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.core.model.FestivalTodayModel
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import java.time.LocalDate
 
 data class HomeUiState(
@@ -25,5 +23,5 @@ data class HomeUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val showAddToFavoritesButton: Boolean = false,
-    val starImageClickStates: ImmutableMap<Int, Boolean> = persistentMapOf(),
+    val isStarImageClicked: ImmutableList<ImmutableList<Boolean>> = persistentListOf(persistentListOf()),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -170,7 +170,7 @@ class HomeViewModel @Inject constructor(
             it.copy(
                 isStarImageClicked = it.todayFestivals.map { festival ->
                     persistentListOf<Boolean>().addAll(List(festival.starInfo.size) { false }).toImmutableList()
-                }.toImmutableList()
+                }.toImmutableList(),
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -11,13 +11,12 @@ import com.unifest.android.core.common.handleException
 import com.unifest.android.core.data.repository.FestivalRepository
 import com.unifest.android.core.data.repository.LikedFestivalRepository
 import com.unifest.android.core.designsystem.R
-import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.FestivalModel
+import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.StarInfoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -79,14 +78,17 @@ class HomeViewModel @Inject constructor(
                         schoolName = "건국대학교",
                         starInfo = listOf(
                             StarInfoModel(
-                                name = "비",
+                                starId = 1,
+                                name = "뉴진스",
                                 imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
+                                starId = 2,
                                 name = "싸이",
                                 imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
+                                starId = 3,
                                 name = "아이유",
                                 imgUrl = "https://picsum.photos/38",
                             ),
@@ -102,15 +104,23 @@ class HomeViewModel @Inject constructor(
                         schoolName = "서울대학교",
                         starInfo = listOf(
                             StarInfoModel(
-                                name = "비",
+                                starId = 4,
+                                name = "아이브",
                                 imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
+                                starId = 2,
                                 name = "싸이",
                                 imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
-                                name = "아이유",
+                                starId = 5,
+                                name = "르세라핌",
+                                imgUrl = "https://picsum.photos/38",
+                            ),
+                            StarInfoModel(
+                                starId = 6,
+                                name = "박재범",
                                 imgUrl = "https://picsum.photos/38",
                             ),
                         ),
@@ -125,15 +135,28 @@ class HomeViewModel @Inject constructor(
                         schoolName = "연세대학교",
                         starInfo = listOf(
                             StarInfoModel(
-                                name = "비",
+                                starId = 7,
+                                name = "지코",
                                 imgUrl = "https://picsum.photos/36",
                             ),
                             StarInfoModel(
+                                starId = 2,
                                 name = "싸이",
                                 imgUrl = "https://picsum.photos/37",
                             ),
                             StarInfoModel(
-                                name = "아이유",
+                                starId = 8,
+                                name = "아일릿",
+                                imgUrl = "https://picsum.photos/38",
+                            ),
+                            StarInfoModel(
+                                starId = 9,
+                                name = "헤이즈",
+                                imgUrl = "https://picsum.photos/38",
+                            ),
+                            StarInfoModel(
+                                starId = 10,
+                                name = "10cm",
                                 imgUrl = "https://picsum.photos/38",
                             ),
                         ),
@@ -143,6 +166,13 @@ class HomeViewModel @Inject constructor(
                 ),
             )
         }
+        _uiState.update {
+            it.copy(
+                isStarImageClicked = it.todayFestivals.map { festival ->
+                    persistentListOf<Boolean>().addAll(List(festival.starInfo.size) { false }).toImmutableList()
+                }.toImmutableList()
+            )
+        }
     }
 
     fun onHomeUiAction(action: HomeUiAction) {
@@ -150,8 +180,7 @@ class HomeViewModel @Inject constructor(
             is HomeUiAction.OnDateSelected -> setSelectedDate(action.date)
             is HomeUiAction.OnAddAsLikedFestivalClick -> addLikeFestival(action.festivalTodayModel)
             is HomeUiAction.OnAddLikedFestivalClick -> setFestivalSearchBottomSheetVisible(true)
-            is HomeUiAction.OnStarImageClick -> toggleStarImageClicked(action.index, true)
-            is HomeUiAction.OnStarImageDismiss -> toggleStarImageClicked(action.index, false)
+            is HomeUiAction.OnToggleStarImageClick -> toggleStarImageClicked(action.scheduleIndex, action.starIndex, action.flag)
         }
     }
 
@@ -170,6 +199,7 @@ class HomeViewModel @Inject constructor(
                 }
                 setLikedFestivalDeleteDialogVisible(true)
             }
+
             is FestivalUiAction.OnDialogButtonClick -> {
                 when (action.type) {
                     ButtonType.CONFIRM -> {
@@ -326,11 +356,18 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun toggleStarImageClicked(index: Int, isClicked: Boolean) {
+    private fun toggleStarImageClicked(scheduleIndex: Int, starIndex: Int, flag: Boolean) {
         _uiState.update { currentState ->
-            val newStates = currentState.starImageClickStates.toMutableMap()
-            newStates[index] = isClicked
-            currentState.copy(starImageClickStates = newStates.toImmutableMap())
+            val updatedList = currentState.isStarImageClicked.mapIndexed { index, list ->
+                if (index == scheduleIndex) {
+                    list.toMutableList().apply {
+                        this[starIndex] = flag
+                    }.toImmutableList()
+                } else {
+                    list
+                }
+            }.toImmutableList()
+            currentState.copy(isStarImageClicked = updatedList)
         }
     }
 }


### PR DESCRIPTION
- 축제 일정 내에 연예인 아이템을 선택했을 때, 같은 List 내에 같은 Index 가 모두 선택되는 것이 아니라, 해당 아이템만 선택되도록 구현했습니다.
- 축제 Title 최대 길이를 fix 시켜, 연예인 목록 리스트가 Row 내에서 항상 같은 지점부터 시작하도록 하였습니다. 

그외)
- 홈 화면 코드 개선(커밋 메세지 참고)
- 오늘의 축제 일정 API 변경 사항 반영