### PR TITLE
[feat] 부스 좋아요 API 연동 및 파생되는 기능 구현 

### DIFF
--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
@@ -7,7 +7,7 @@ import com.unifest.android.core.network.response.AllBooths
 import com.unifest.android.core.network.response.BoothDetail
 import com.unifest.android.core.network.response.Menu
 
-internal fun BoothDetail.toDetailModel(): BoothDetailModel {
+internal fun BoothDetail.toModel(): BoothDetailModel {
     return BoothDetailModel(
         id = id,
         name = name,
@@ -30,19 +30,6 @@ internal fun Menu.toModel(): MenuModel {
         name = name,
         price = price,
         imgUrl = imgUrl,
-    )
-}
-
-internal fun BoothDetail.toAllModel(): AllBoothsModel {
-    return AllBoothsModel(
-        id = id,
-        name = name,
-        category = category,
-        description = description,
-        thumbnail = thumbnail,
-        location = location,
-        latitude = latitude,
-        longitude = longitude,
     )
 }
 

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/BoothRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/BoothRepositoryImpl.kt
@@ -3,8 +3,6 @@ package com.unifest.android.core.data.repository
 import android.annotation.SuppressLint
 import android.content.Context
 import android.provider.Settings
-import com.unifest.android.core.data.mapper.toAllModel
-import com.unifest.android.core.data.mapper.toDetailModel
 import com.unifest.android.core.data.mapper.toModel
 import com.unifest.android.core.data.util.runSuspendCatching
 import com.unifest.android.core.network.request.LikeBoothRequest
@@ -17,7 +15,7 @@ class BoothRepositoryImpl @Inject constructor(
     private val service: UnifestService,
 ) : BoothRepository {
     override suspend fun getPopularBooths(festivalId: Long) = runSuspendCatching {
-        service.getPopularBooths(festivalId).data.map { it.toAllModel() }
+        service.getPopularBooths(festivalId).data.map { it.toModel() }
     }
 
     override suspend fun getAllBooths(festivalId: Long) = runSuspendCatching {
@@ -25,7 +23,7 @@ class BoothRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getBoothDetail(boothId: Long) = runSuspendCatching {
-        service.getBoothDetail(boothId).data.toDetailModel()
+        service.getBoothDetail(boothId).data.toModel()
     }
 
     override suspend fun likeBooth(boothId: Long): Result<Unit> = runSuspendCatching {

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/LikedBoothRepository.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/LikedBoothRepository.kt
@@ -8,4 +8,5 @@ interface LikedBoothRepository {
     suspend fun insertLikedBooth(booth: BoothDetailModel)
     suspend fun deleteLikedBooth(booth: BoothDetailModel)
     suspend fun updateLikedBooth(booth: BoothDetailModel)
+    suspend fun isLikedBooth(booth: BoothDetailModel): Boolean
 }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/LikedBoothRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/LikedBoothRepositoryImpl.kt
@@ -30,4 +30,8 @@ internal class LikedBoothRepositoryImpl @Inject constructor(
     override suspend fun updateLikedBooth(booth: BoothDetailModel) {
         likedBoothDao.updateLikedBooth(booth.id, booth.isLiked)
     }
+
+    override suspend fun isLikedBooth(booth: BoothDetailModel): Boolean {
+        return likedBoothDao.isLikedBooth(booth.id)
+    }
 }

--- a/core/database/src/main/kotlin/com/unifest/android/core/database/LikedBoothDao.kt
+++ b/core/database/src/main/kotlin/com/unifest/android/core/database/LikedBoothDao.kt
@@ -21,4 +21,7 @@ interface LikedBoothDao {
 
     @Query("UPDATE liked_booth SET is_liked = :isLiked WHERE id = :id")
     suspend fun updateLikedBooth(id: Long, isLiked: Boolean)
+
+    @Query("SELECT EXISTS(SELECT * FROM liked_booth WHERE id = :id)")
+    suspend fun isLikedBooth(id: Long): Boolean
 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="booth_bookmarked_message">관심 주점으로 저장했습니다.</string>
     <string name="liked_booth_removed_message">관심 주점에서 삭제했습니다.</string>
     <string name="liked_booth_removed_failed_message">관심 주점에서 삭제를 실패했습니다.</string>
+    <string name="booth_empty_menu">등록된 메뉴가 없어요.</string>
 
     <!--    Map    -->
     <string name="map_booth_search_text_field_hint">부스 / 주점을 검색해보세요.</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="permission_required">권한 필요</string>
     <string name="go_to_app_setting">앱 설정으로 이동</string>
     <string name="check">확인</string>
+    <string name="map_popular_booth_update_failed_message">인기 부스 갱신을 실패했습니다.</string>
 
     <!--    Menu    -->
     <string name="menu_title">메뉴</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -42,7 +42,8 @@
     <string name="booth_waiting_button">웨이팅 하기</string>
     <string name="booth_waiting_button_invalid">웨이팅 기능을 지원하지 않는 부스입니다</string>
     <string name="booth_bookmarked_message">관심 주점으로 저장했습니다.</string>
-    <string name="booth_bookmark_removed_message">관심 주점에서 삭제했습니다.</string>
+    <string name="liked_booth_removed_message">관심 주점에서 삭제했습니다.</string>
+    <string name="liked_booth_removed_failed_message">관심 주점에서 삭제를 실패했습니다.</string>
 
     <!--    Map    -->
     <string name="map_booth_search_text_field_hint">부스 / 주점을 검색해보세요.</string>

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
@@ -20,7 +20,7 @@ data class PopularBoothsResponse(
     @SerialName("message")
     val message: String,
     @SerialName("data")
-    val data: List<BoothDetail>,
+    val data: List<AllBooths>,
 )
 
 @Serializable

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedBoothItem.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedBoothItem.kt
@@ -67,7 +67,7 @@ fun LikedBoothItem(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = booth.category,
+                    text = booth.warning,
                     style = Title5,
                     color = Color(0xFF545454),
                     maxLines = 1,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -54,6 +54,7 @@ import com.unifest.android.core.designsystem.theme.BoothCaution
 import com.unifest.android.core.designsystem.theme.BoothLocation
 import com.unifest.android.core.designsystem.theme.BoothTitle1
 import com.unifest.android.core.designsystem.theme.Content2
+import com.unifest.android.core.designsystem.theme.Content3
 import com.unifest.android.core.designsystem.theme.MainColor
 import com.unifest.android.core.designsystem.theme.MenuPrice
 import com.unifest.android.core.designsystem.theme.MenuTitle
@@ -204,7 +205,26 @@ fun BoothDetailContent(
         item { Spacer(modifier = Modifier.height(22.dp)) }
         item { MenuText() }
         item { Spacer(modifier = Modifier.height(16.dp)) }
-        items(uiState.boothDetailInfo.menus) { menu -> MenuItem(menu) }
+        if (uiState.boothDetailInfo.menus.isEmpty()) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.booth_empty_menu),
+                        modifier = Modifier.padding(top = 76.dp),
+                        color = Color(0xFF7E7E7E),
+                        style = Content3,
+                    )
+                }
+            }
+        } else {
+            items(
+                items = uiState.boothDetailInfo.menus,
+                key = { it.id },
+            ) { menu -> MenuItem(menu) }
+        }
     }
 }
 

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
@@ -70,6 +71,11 @@ fun BoothLocationScreen(
         NaverMap(
             cameraPositionState = cameraPositionState,
             modifier = Modifier.fillMaxSize(),
+            uiSettings = MapUiSettings(
+                isZoomControlEnabled = false,
+                isScaleBarEnabled = false,
+                isLogoClickEnabled = false,
+            ),
         ) {
             Marker(
                 state = MarkerState(position = LatLng(uiState.boothDetailInfo.latitude.toDouble(), uiState.boothDetailInfo.longitude.toDouble())),

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -5,6 +5,7 @@ import com.unifest.android.core.model.BoothDetailModel
 data class BoothUiState(
     val isLoading: Boolean = false,
     val boothDetailInfo: BoothDetailModel = BoothDetailModel(),
+    val isLiked: Boolean = false,
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
 )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -92,7 +92,7 @@ class BoothViewModel @Inject constructor(
                     }
                     if (currentBookmarkFlag) {
                         likedBoothRepository.deleteLikedBooth(_uiState.value.boothDetailInfo)
-                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmark_removed_message),))
+                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_message),))
                     } else {
                         likedBoothRepository.insertLikedBooth(_uiState.value.boothDetailInfo)
                         _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmarked_message)))

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -53,9 +53,16 @@ class BoothViewModel @Inject constructor(
             boothRepository.getBoothDetail(boothId)
                 .onSuccess { booth ->
                     _uiState.update {
-                        it.copy(
-                            boothDetailInfo = booth,
-                        )
+                        it.copy(boothDetailInfo = booth)
+                    }
+                    if (likedBoothRepository.isLikedBooth(booth)) {
+                        _uiState.update {
+                            it.copy(
+                                boothDetailInfo = it.boothDetailInfo.copy(
+                                    isLiked = true,
+                                ),
+                            )
+                        }
                     }
                 }
                 .onFailure { exception ->
@@ -92,7 +99,7 @@ class BoothViewModel @Inject constructor(
                     }
                     if (currentBookmarkFlag) {
                         likedBoothRepository.deleteLikedBooth(_uiState.value.boothDetailInfo)
-                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_message),))
+                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_message)))
                     } else {
                         likedBoothRepository.insertLikedBooth(_uiState.value.boothDetailInfo)
                         _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmarked_message)))

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -23,7 +23,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class BoothViewModel @Inject constructor(
-    @Suppress("unused")
     private val boothRepository: BoothRepository,
     private val likedBoothRepository: LikedBoothRepository,
     savedStateHandle: SavedStateHandle,
@@ -81,23 +80,27 @@ class BoothViewModel @Inject constructor(
         val currentBookmarkFlag = _uiState.value.boothDetailInfo.isLiked
         val newBookmarkFlag = !currentBookmarkFlag
         viewModelScope.launch {
-            if (currentBookmarkFlag) {
-                likedBoothRepository.deleteLikedBooth(_uiState.value.boothDetailInfo)
-            } else {
-                likedBoothRepository.insertLikedBooth(_uiState.value.boothDetailInfo)
-            }
-//            _uiState.update {
-//                it.copy(
-//                    isBookmarked = newBookmarkFlag,
-//                    bookmarkCount = it.bookmarkCount + if (newBookmarkFlag) 1 else -1,
-//                )
-//            }
-            _uiEvent.send(
-                BoothUiEvent.ShowSnackBar(
-                    if (newBookmarkFlag) UiText.StringResource(R.string.booth_bookmarked_message)
-                    else UiText.StringResource(R.string.booth_bookmark_removed_message),
-                ),
-            )
+            boothRepository.likeBooth(boothId)
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            boothDetailInfo = it.boothDetailInfo.copy(
+                                isLiked = newBookmarkFlag,
+                                likes = it.boothDetailInfo.likes + if (newBookmarkFlag) 1 else -1,
+                            ),
+                        )
+                    }
+                    if (currentBookmarkFlag) {
+                        likedBoothRepository.deleteLikedBooth(_uiState.value.boothDetailInfo)
+                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmark_removed_message),))
+                    } else {
+                        likedBoothRepository.insertLikedBooth(_uiState.value.boothDetailInfo)
+                        _uiEvent.send(BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmarked_message)))
+                    }
+                }
+                .onFailure { exception ->
+                    handleException(exception, this@BoothViewModel)
+                }
         }
     }
 

--- a/feature/liked-booth/src/main/kotlin/com/unifest/android/feature/liked_booth/viewmodel/LikedBoothViewModel.kt
+++ b/feature/liked-booth/src/main/kotlin/com/unifest/android/feature/liked_booth/viewmodel/LikedBoothViewModel.kt
@@ -3,6 +3,7 @@ package com.unifest.android.feature.liked_booth.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.UiText
+import com.unifest.android.core.data.repository.BoothRepository
 import com.unifest.android.core.data.repository.LikedBoothRepository
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.model.BoothDetailModel
@@ -21,6 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LikedBoothViewModel @Inject constructor(
+    private val boothRepository: BoothRepository,
     private val likedBoothRepository: LikedBoothRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LikedBoothUiState())
@@ -67,130 +69,19 @@ class LikedBoothViewModel @Inject constructor(
 
     private fun deleteLikedBooth(booth: BoothDetailModel) {
         viewModelScope.launch {
-            updateLikedBooth(booth)
-            delay(500)
-            likedBoothRepository.deleteLikedBooth(booth)
-            _uiEvent.send(LikedBoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmark_removed_message)))
+            boothRepository.likeBooth(booth.id)
+                .onSuccess {
+                    updateLikedBooth(booth)
+                    delay(500)
+                    likedBoothRepository.deleteLikedBooth(booth)
+                    _uiEvent.send(LikedBoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_message)))
+                }.onFailure {
+                    _uiEvent.send(LikedBoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_failed_message)))
+                }
         }
     }
 
     private suspend fun updateLikedBooth(booth: BoothDetailModel) {
         likedBoothRepository.updateLikedBooth(booth.copy(isLiked = false))
     }
-
-//    init {
-//        _uiState.update {
-//            it.copy(
-//                likedBoothList = persistentListOf(
-//                    BoothDetailEntity(
-//                        id = 1,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                    BoothDetailEntity(
-//                        id = 2,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                    BoothDetailEntity(
-//                        id = 3,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                    BoothDetailEntity(
-//                        id = 4,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                    BoothDetailEntity(
-//                        id = 5,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                    BoothDetailEntity(
-//                        id = 6,
-//                        name = "부스 이름",
-//                        category = "음식",
-//                        description = "부스 설명",
-//                        warning = "주의사항",
-//                        location = "부스 위치",
-//                        latitude = 0.0f,
-//                        longitude = 0.0f,
-//                        menus = listOf(
-//                            MenuEntity(
-//                                id = 1,
-//                                name = "메뉴 이름",
-//                                price = 1000,
-//                                imgUrl = "",
-//                            ),
-//                        ),
-//                    ),
-//                ),
-//            )
-//        }
 }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -98,6 +98,7 @@ internal fun MainScreen(
             mapNavGraph(
                 padding = innerPadding,
                 navigateToBoothDetail = navigator::navigateToBoothDetail,
+                onShowSnackBar = onShowSnackBar,
             )
             boothNavGraph(
                 padding = innerPadding,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -63,6 +63,7 @@ import com.naver.maps.map.compose.rememberFusedLocationSource
 import com.naver.maps.map.overlay.Marker
 import com.unifest.android.core.common.FestivalUiAction
 import com.unifest.android.core.common.ObserveAsEvents
+import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.common.extension.goToAppSettings
 import com.unifest.android.core.designsystem.ComponentPreview
@@ -97,6 +98,7 @@ import ted.gun0912.clustering.naver.TedNaverClustering
 internal fun MapRoute(
     padding: PaddingValues,
     navigateToBoothDetail: (Long) -> Unit,
+    onShowSnackBar: (UiText) -> Unit,
     viewModel: MapViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -123,6 +125,7 @@ internal fun MapRoute(
 
             is MapUiEvent.GoToAppSettings -> activity.goToAppSettings()
             is MapUiEvent.NavigateToBoothDetail -> navigateToBoothDetail(event.boothId)
+            is MapUiEvent.ShowSnackBar -> onShowSnackBar(event.message)
         }
     }
 

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/navigation/MapNavigation.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/navigation/MapNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.unifest.android.core.common.UiText
 import com.unifest.android.feature.map.MapRoute
 
 const val MAP_ROUTE = "map_route"
@@ -16,11 +17,13 @@ fun NavController.navigateToMap(navOptions: NavOptions) {
 fun NavGraphBuilder.mapNavGraph(
     padding: PaddingValues,
     navigateToBoothDetail: (Long) -> Unit,
+    onShowSnackBar: (UiText) -> Unit,
 ) {
     composable(route = MAP_ROUTE) {
         MapRoute(
             padding = padding,
             navigateToBoothDetail = navigateToBoothDetail,
+            onShowSnackBar = onShowSnackBar,
         )
     }
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiEvent.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiEvent.kt
@@ -1,7 +1,10 @@
 package com.unifest.android.feature.map.viewmodel
 
+import com.unifest.android.core.common.UiText
+
 sealed interface MapUiEvent {
     data object RequestLocationPermission : MapUiEvent
     data object GoToAppSettings : MapUiEvent
     data class NavigateToBoothDetail(val boothId: Long) : MapUiEvent
+    data class ShowSnackBar(val message: UiText) : MapUiEvent
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -6,12 +6,14 @@ import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ButtonType
 import com.unifest.android.core.common.ErrorHandlerActions
 import com.unifest.android.core.common.FestivalUiAction
+import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.handleException
 import com.unifest.android.core.data.repository.BoothRepository
 import com.unifest.android.core.data.repository.FestivalRepository
 import com.unifest.android.core.data.repository.LikedFestivalRepository
 import com.unifest.android.core.data.repository.OnboardingRepository
 import com.unifest.android.core.model.FestivalModel
+import com.unifest.android.core.designsystem.R
 import com.unifest.android.feature.map.mapper.toMapModel
 import com.unifest.android.feature.map.model.AllBoothsMapModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,168 +49,6 @@ class MapViewModel @Inject constructor(
         checkMapOnboardingCompletion()
         checkFestivalOnboardingCompletion()
         observeLikedFestivals()
-
-//        val boothList = listOf(
-//            BoothDetailModel(
-//                id = 1L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54053013863604F,
-//                longitude = 127.07505652524804F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 2L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54111712868565F,
-//                longitude = 127.07839319326257F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 3L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.5414744247141F,
-//                longitude = 127.07779237844323F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 4L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54224856023523F,
-//                longitude = 127.07605430700158F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 5L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54003672313541F,
-//                longitude = 127.07653710462426F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 6L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.53998567996623F,
-//                longitude = 37.53998567996623F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 7L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54152546686414F,
-//                longitude = 127.07353303052759F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 8L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54047909580466F,
-//                longitude = 127.07398364164209F,
-//                menus = emptyList(),
-//            ),
-//        )
-//
-//        _uiState.update {
-//            it.copy(
-//                festivalInfo = FestivalModel(
-//                    schoolName = "건국대학교",
-//                    latitude = 126.957f,
-//                    longitude = 37.460f,
-//                ),
-//                boothList = boothList
-//                    .map { booth -> booth.toMapModel() }
-//                    .toImmutableList(),
-//                selectedBoothList = persistentListOf(),
-//                festivalSearchResults = persistentListOf(
-//                    FestivalModel(
-//                        1,
-//                        1,
-//                        "https://picsum.photos/36",
-//                        "서울대학교",
-//                        "설대축제",
-//                        "2024-04-21",
-//                        "2024-04-23",
-//                        126.957f,
-//                        37.460f,
-//                    ),
-//                    FestivalModel(
-//                        2,
-//                        2,
-//                        "https://picsum.photos/36",
-//                        "연세대학교",
-//                        "연대축제",
-//                        "2024-04-21",
-//                        "2024-04-23",
-//                        126.957f,
-//                        37.460f,
-//                    ),
-//                    FestivalModel(
-//                        3,
-//                        3,
-//                        "https://picsum.photos/36",
-//                        "고려대학교",
-//                        "고대축제",
-//                        "2024-04-21",
-//                        "2024-04-23",
-//                        126.957f,
-//                        37.460f,
-//                    ),
-//                    FestivalModel(
-//                        4,
-//                        4,
-//                        "https://picsum.photos/36",
-//                        "성균관대학교",
-//                        "성대축제",
-//                        "2024-04-21",
-//                        "2024-04-23",
-//                        126.957f,
-//                        37.460f,
-//                    ),
-//                    FestivalModel(
-//                        5,
-//                        5,
-//                        "https://picsum.photos/36",
-//                        "건국대학교",
-//                        "건대축제",
-//                        "2024-04-21",
-//                        "2024-04-23",
-//                        126.957f,
-//                        37.460f,
-//                    ),
-//                ),
-//            )
-//        }
     }
 
     fun onPermissionResult(isGranted: Boolean) {
@@ -453,77 +293,26 @@ class MapViewModel @Inject constructor(
     }
 
     private fun setEnablePopularMode() {
-//        val popularBoothList = listOf(
-//            BoothDetailModel(
-//                id = 1L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54053013863604F,
-//                longitude = 127.07505652524804F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 2L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54111712868565F,
-//                longitude = 127.07839319326257F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 3L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.5414744247141F,
-//                longitude = 127.07779237844323F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 4L,
-//                name = "학생회 부스",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                location = "청심대 앞",
-//                warning = "",
-//                latitude = 37.54224856023523F,
-//                longitude = 127.07605430700158F,
-//                menus = emptyList(),
-//            ),
-//            BoothDetailModel(
-//                id = 5L,
-//                name = "컴공 주점",
-//                category = "",
-//                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다. 100번째 방문자에게 깜짝 선물 증정 이벤트를 하고 있으니 많은 관심 부탁드려요~!",
-//                warning = "",
-//                location = "청심대 앞",
-//                latitude = 37.54003672313541F,
-//                longitude = 127.07653710462426F,
-//                menus = emptyList(),
-//            ),
-//        )
         if (_uiState.value.isBoothSelectionMode) {
             viewModelScope.launch {
-                _uiState.update {
-                    it.copy(
-                        isBoothSelectionMode = false,
-                    )
-                }
-                delay(500)
-                _uiState.update {
-                    it.copy(
-                        selectedBoothList = _uiState.value.popularBoothList.map { it.toMapModel() }.toImmutableList(),
-                        isPopularMode = true,
-                    )
-                }
+                boothRepository.getPopularBooths(_uiState.value.festivalInfo.festivalId)
+                    .onSuccess { booths ->
+                        _uiState.update {
+                            it.copy(
+                                selectedBoothList = booths.map { it.toMapModel() }.toImmutableList(),
+                                isBoothSelectionMode = false,
+                            )
+                        }
+                        delay(500)
+                        _uiState.update {
+                            it.copy(
+                                selectedBoothList = _uiState.value.popularBoothList.map { it.toMapModel() }.toImmutableList(),
+                                isPopularMode = true,
+                            )
+                        }
+                    }.onFailure {
+                        _uiEvent.send(MapUiEvent.ShowSnackBar(UiText.StringResource(R.string.map_popular_booth_update_failed_message)))
+                    }
             }
         } else {
             _uiState.update {

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ButtonType
 import com.unifest.android.core.common.FestivalUiAction
 import com.unifest.android.core.common.UiText
+import com.unifest.android.core.data.repository.BoothRepository
 import com.unifest.android.core.data.repository.LikedBoothRepository
 import com.unifest.android.core.data.repository.LikedFestivalRepository
 import com.unifest.android.core.designsystem.R
@@ -28,6 +29,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MenuViewModel @Inject constructor(
     private val likedFestivalRepository: LikedFestivalRepository,
+    private val boothRepository: BoothRepository,
     private val likedBoothRepository: LikedBoothRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MenuUiState())
@@ -153,10 +155,15 @@ class MenuViewModel @Inject constructor(
 
     private fun deleteLikedBooth(booth: BoothDetailModel) {
         viewModelScope.launch {
-            updateLikedBooth(booth)
-            delay(500)
-            likedBoothRepository.deleteLikedBooth(booth)
-            _uiEvent.send(MenuUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_bookmark_removed_message)))
+            boothRepository.likeBooth(booth.id)
+                .onSuccess {
+                    updateLikedBooth(booth)
+                    delay(500)
+                    likedBoothRepository.deleteLikedBooth(booth)
+                    _uiEvent.send(MenuUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_message)))
+                }.onFailure {
+                    _uiEvent.send(MenuUiEvent.ShowSnackBar(UiText.StringResource(R.string.liked_booth_removed_failed_message)))
+                }
         }
     }
 


### PR DESCRIPTION
feat)
- 부스 좋아요 API 연동
- 축제 내 인기 부스 API 변경 사항 반영
- 부스 위치 화면 네이버 맵 세팅 설정
- 메뉴, 관심 부스 화면 좋아요 취소 API 연동
- 맵 화면 인기 부스 갱신 기능 구현(좋아요를 누르고 돌아왔을 때, 인기 부스 랭킹 갱신을 위함)
- 부스 화면 메뉴가 없는 경우에 대한 케이스 처리(등록된 메뉴가 없어요)
- 상세 조회한 부스가 내가 이미 좋아요를 누른 부스 일 경우, 북마크가 체크되도록 구현

fix)
- 메뉴 화면 LikedBoothItem 잘못 매핑된 정보 수정(category -> warning)