### PR TITLE
[fix] 관심축제에 건대가 없을시 부스 데이터를 받아오지 못하던 버그 수정

### DIFF
--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -191,7 +191,7 @@ class MapViewModel @Inject constructor(
 
     private fun getPopularBooths() {
         viewModelScope.launch {
-            boothRepository.getPopularBooths(_uiState.value.festivalInfo.festivalId)
+            boothRepository.getPopularBooths(1)
                 .onSuccess { booths ->
                     _uiState.update {
                         it.copy(popularBoothList = booths.toImmutableList())
@@ -204,7 +204,7 @@ class MapViewModel @Inject constructor(
 
     private fun getAllBooths() {
         viewModelScope.launch {
-            boothRepository.getAllBooths(_uiState.value.festivalInfo.festivalId)
+            boothRepository.getAllBooths(1)
                 .onSuccess { booths ->
                     _uiState.update {
                         it.copy(
@@ -352,7 +352,7 @@ class MapViewModel @Inject constructor(
     private fun setEnablePopularMode() {
         if (_uiState.value.isBoothSelectionMode) {
             viewModelScope.launch {
-                boothRepository.getPopularBooths(_uiState.value.festivalInfo.festivalId)
+                boothRepository.getPopularBooths(1)
                     .onSuccess { booths ->
                         _uiState.update {
                             it.copy(


### PR DESCRIPTION
건국대학교만 현재 서비스함에 따라 다른 학교를 비활성화 했는데, 관심축제에 건대가 포함되지 않을시 부스정보를 가져오지 못하던 파생되는 문제를 수정