### PR TITLE
[fix] [#157] [#158] [#159] [#160] minor bugs fix

### DIFF
--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -68,7 +68,7 @@ fun BoothLocationScreen(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         val cameraPositionState = rememberCameraPositionState {
-            position = CameraPosition(LatLng(37.5420, 127.07673671067072), 14.8)
+            position = CameraPosition(LatLng(uiState.boothDetailInfo.latitude.toDouble(), uiState.boothDetailInfo.longitude.toDouble()), 14.8)
         }
         NaverMap(
             cameraPositionState = cameraPositionState,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -68,7 +68,7 @@ fun BoothLocationScreen(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         val cameraPositionState = rememberCameraPositionState {
-            position = CameraPosition(LatLng(uiState.boothDetailInfo.latitude.toDouble(), uiState.boothDetailInfo.longitude.toDouble()), 14.0)
+            position = CameraPosition(LatLng(37.5420, 127.07673671067072), 14.8)
         }
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -117,7 +117,7 @@ fun BoothLocationAppBar(
                 color = Color.White,
                 shape = RoundedCornerShape(bottomStart = 32.dp, bottomEnd = 32.dp),
             )
-            .padding(8.dp),
+            .padding(vertical = 8.dp, horizontal = 12.dp),
         navigationIcon = {
             IconButton(onClick = onBackClick) {
                 Icon(

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -68,7 +68,7 @@ fun BoothLocationScreen(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         val cameraPositionState = rememberCameraPositionState {
-            position = CameraPosition(LatLng(uiState.boothDetailInfo.latitude.toDouble(), uiState.boothDetailInfo.longitude.toDouble()), 14.8)
+            position = CameraPosition(LatLng(37.5420, 127.07673671067072), 14.8)
         }
         NaverMap(
             cameraPositionState = cameraPositionState,

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
@@ -12,7 +12,7 @@ data class IntroUiState(
     val searchText: TextFieldValue = TextFieldValue(),
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedFestivals: PersistentList<FestivalModel> = persistentListOf(),
-    val selectedRegion: String = "",
+    val selectedRegion: String = "전체",
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
 )

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -156,7 +156,7 @@ internal fun MapScreen(
 ) {
     val activity = LocalContext.current.findActivity()
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition(LatLng(37.54118132567716, 127.07673671067072), 14.8)
+        position = CameraPosition(LatLng(37.5430, 127.07673671067072), 14.8)
     }
     val rotationState by animateFloatAsState(targetValue = if (uiState.isPopularMode) 180f else 0f)
     val pagerState = rememberPagerState(pageCount = { uiState.selectedBoothList.size })
@@ -226,7 +226,6 @@ fun MapContent(
         // TODO 클러스터링 마커 커스텀
         // TODO 지도 중앙 위치 조정
         NaverMap(
-            modifier = Modifier.padding(top = 128.dp),
             cameraPositionState = cameraPositionState,
             locationSource = rememberFusedLocationSource(),
             uiSettings = MapUiSettings(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -272,7 +272,7 @@ class MapViewModel @Inject constructor(
 
     private fun clearBoothSearchText() {
         _uiState.update {
-            it.copy(festivalSearchText = TextFieldValue())
+            it.copy(boothSearchText = TextFieldValue())
         }
     }
 


### PR DESCRIPTION
1. 157번 이슈는 패딩을 추가하면서 발생한 문제로, 흰 사각형이 항상 보여 어색하던 이슈였습니다. 패딩을 지우고 대신 카메라 위치를 조정해 수정해주었습니다
2. 158번 이슈는 인트로 화면에서 처음으로 진입했을시에는 selectedRegion이 값이 지정되어있지 않아 ""로 지정되어져 아무 축제값도 보여주지못하는 이슈였습니다. UiState에서 기본값으로 전체를 설정해줘 해결했습니다. (다른 지역검색시 selectedRegion이 새로 지정되므로 문제가 발생하지않음)
3. 159번 이슈는 맵 탑앱바에서의 부스 SearchTextField에서 clearText가 작동하지 않았는데, `it.copy(festivalSearchText = TextFieldValue())` 로 작성되어있던 이슈였습니다. 수정했습니다
4. 160번 이슈는 양옆에 horizontal 패딩을 4dp씩 주어 해결했습니다. 이전 화면인 부스 디테일화면의 앱바에서의 뒤로가기 위치가 같았다면 다른식으로 해결했을텐데 그렇진 않아서 쉽게 해결해뒀습니다. 추가로 부스 상세 위치를 보여주는 지도의 카메라 줌을 수정해주었습니다.
![스크린샷 2024-05-08 212314](https://github.com/Project-Unifest/unifest-android/assets/60922290/9f33ef26-2126-4e44-aa41-f8e0fdb85d26)
![스크린샷 2024-05-08 212835](https://github.com/Project-Unifest/unifest-android/assets/60922290/9b4b3874-b3fd-42b3-9dad-85ac411cf922)
