### PR TITLE
[fix] QA 내역 반영

### DIFF
--- a/build-logic/src/main/kotlin/com/unifest/android/Config.kt
+++ b/build-logic/src/main/kotlin/com/unifest/android/Config.kt
@@ -4,8 +4,8 @@ internal object ApplicationConfig {
     const val MinSdk = 26
     const val TargetSdk = 34
     const val CompileSdk = 34
-    const val VersionCode = 2
-    const val VersionName = "0.1.1"
+    const val VersionCode = 3
+    const val VersionName = "0.1.2"
     val JavaVersion = org.gradle.api.JavaVersion.VERSION_17
     const val JavaVersionAsInt = 17
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
@@ -17,7 +17,7 @@ fun AutoResizedText(
     text: String,
     style: TextStyle,
     modifier: Modifier = Modifier,
-    color: Color = style.color
+    color: Color = style.color,
 ) {
     var resizedTextStyle by remember {
         mutableStateOf(style)
@@ -42,15 +42,15 @@ fun AutoResizedText(
             if (result.didOverflowWidth) {
                 if (style.fontSize.isUnspecified) {
                     resizedTextStyle = resizedTextStyle.copy(
-                        fontSize = defaultFontSize
+                        fontSize = defaultFontSize,
                     )
                 }
                 resizedTextStyle = resizedTextStyle.copy(
-                    fontSize = resizedTextStyle.fontSize * 0.95
+                    fontSize = resizedTextStyle.fontSize * 0.95,
                 )
             } else {
                 shouldDraw = true
             }
-        }
+        },
     )
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
@@ -1,0 +1,56 @@
+package com.unifest.android.core.designsystem.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.isUnspecified
+
+@Composable
+fun AutoResizedText(
+    text: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    color: Color = style.color
+) {
+    var resizedTextStyle by remember {
+        mutableStateOf(style)
+    }
+    var shouldDraw by remember {
+        mutableStateOf(false)
+    }
+
+    val defaultFontSize = style.fontSize
+
+    Text(
+        text = text,
+        color = color,
+        modifier = modifier.drawWithContent {
+            if (shouldDraw) {
+                drawContent()
+            }
+        },
+        softWrap = false,
+        style = resizedTextStyle,
+        onTextLayout = { result ->
+            if (result.didOverflowWidth) {
+                if (style.fontSize.isUnspecified) {
+                    resizedTextStyle = resizedTextStyle.copy(
+                        fontSize = defaultFontSize
+                    )
+                }
+                resizedTextStyle = resizedTextStyle.copy(
+                    fontSize = resizedTextStyle.fontSize * 0.95
+                )
+            } else {
+                shouldDraw = true
+            }
+        }
+    )
+}

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/StarImage.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/StarImage.kt
@@ -3,15 +3,14 @@ package com.unifest.android.core.ui.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextAlign
 import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.component.AutoResizedText
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content9
 import com.unifest.android.core.designsystem.theme.UnifestTheme
@@ -45,11 +44,9 @@ fun StarImage(
                     .matchParentSize()
                     .background(Color.Black.copy(alpha = 0.6f)),
             )
-            Text(
+            AutoResizedText(
                 text = label,
-                modifier = Modifier.align(Alignment.Center),
                 color = Color.White,
-                textAlign = TextAlign.Center,
                 style = Content9,
             )
         }

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/StarImage.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/StarImage.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content9
@@ -46,9 +47,10 @@ fun StarImage(
             )
             Text(
                 text = label,
-                color = Color.White,
-                style = Content9,
                 modifier = Modifier.align(Alignment.Center),
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                style = Content9,
             )
         }
     }
@@ -63,6 +65,19 @@ fun StarImagePreview() {
             onClick = {},
             isClicked = false,
             label = "",
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+fun StarImageClickedPreview() {
+    UnifestTheme {
+        StarImage(
+            imgUrl = "",
+            onClick = {},
+            isClicked = true,
+            label = "키스오브라이프",
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -311,7 +311,7 @@ fun Day(
     Column(
         modifier = Modifier.clickable(
             enabled = isSelectable,
-            showRipple = !isSelected,
+            showRipple = false,
             onClick = { onClick(day) },
         ),
     ) {

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -118,7 +118,8 @@ fun IntroScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = 60.dp),
             ) {
                 InformationText()
                 SearchTextField(


### PR DESCRIPTION
1. 연예인 이름이 2줄이 되면 중앙정렬이 안되는 문제를 수정하고, 글자크기를 조절해 한줄로 표현되도록 변경
![KakaoTalk_20240514_110653131](https://github.com/Project-Unifest/unifest-android/assets/60922290/33fffa48-0c80-43ec-abeb-68cd3362a261)

2. 인트로 화면에서 버튼이 학교를 가리는 문제 해결
![KakaoTalk_20240514_111043282](https://github.com/Project-Unifest/unifest-android/assets/60922290/374b9d20-86e7-49ab-9176-9362fb34fe79)

3. 캘린더에 리플이 어색하던 문제를 해결