### PR TITLE
[fix] qa 2차

### DIFF
--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
@@ -14,9 +14,9 @@ internal fun BoothDetail.toModel(): BoothDetailModel {
         id = id,
         name = name,
         category = category,
-        description = description,
+        description = description ?: "",
         thumbnail = thumbnail,
-        warning = warning,
+        warning = warning ?: "",
         location = location,
         latitude = latitude,
         longitude = longitude,
@@ -29,7 +29,7 @@ internal fun Menu.toModel(): MenuModel {
         id = id,
         name = name,
         price = price,
-        imgUrl = imgUrl,
+        imgUrl = imgUrl ?: "",
     )
 }
 

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
@@ -15,7 +15,7 @@ internal fun BoothDetail.toModel(): BoothDetailModel {
         name = name,
         category = category,
         description = description ?: "",
-        thumbnail = thumbnail,
+        thumbnail = thumbnail ?: "",
         warning = warning ?: "",
         location = location,
         latitude = latitude,

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
@@ -52,11 +52,11 @@ data class BoothDetail(
     @SerialName("category")
     val category: String,
     @SerialName("description")
-    val description: String,
+    val description: String? = null,
     @SerialName("thumbnail")
     val thumbnail: String,
     @SerialName("warning")
-    val warning: String,
+    val warning: String? = null,
     @SerialName("location")
     val location: String,
     @SerialName("latitude")
@@ -76,7 +76,7 @@ data class Menu(
     @SerialName("price")
     val price: Int,
     @SerialName("imgUrl")
-    val imgUrl: String,
+    val imgUrl: String? = null,
 )
 
 @Serializable

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/BoothResponse.kt
@@ -54,7 +54,7 @@ data class BoothDetail(
     @SerialName("description")
     val description: String? = null,
     @SerialName("thumbnail")
-    val thumbnail: String,
+    val thumbnail: String? = null,
     @SerialName("warning")
     val warning: String? = null,
     @SerialName("location")

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
@@ -34,7 +34,6 @@ import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.component.FestivalSearchTextField
 import com.unifest.android.core.designsystem.component.LikedFestivalDeleteDialog
-import com.unifest.android.core.designsystem.component.LikedFestivalToolTip
 import com.unifest.android.core.designsystem.component.UnifestHorizontalDivider
 import com.unifest.android.core.designsystem.theme.Content3
 import com.unifest.android.core.designsystem.theme.Title3

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalBottomSheet.kt
@@ -53,7 +53,6 @@ fun FestivalSearchBottomSheet(
     isSearchMode: Boolean,
     isLikedFestivalDeleteDialogVisible: Boolean,
     onFestivalUiAction: (FestivalUiAction) -> Unit,
-    isOnboardingCompleted: Boolean = false,
     isEditMode: Boolean = false,
 ) {
 //    val bottomSheetState = rememberFlexibleBottomSheetState(
@@ -121,6 +120,7 @@ fun FestivalSearchBottomSheet(
                 Spacer(modifier = Modifier.height(21.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 20.dp),
@@ -129,20 +129,6 @@ fun FestivalSearchBottomSheet(
                         text = stringResource(id = R.string.intro_liked_festivals_title),
                         style = Title3,
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    if (!isOnboardingCompleted) {
-                        LikedFestivalToolTip(
-                            completeOnboarding = {
-                                onFestivalUiAction(FestivalUiAction.OnTooltipClick)
-                            },
-                        )
-                    }
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
                     TextButton(
                         onClick = {
                             onFestivalUiAction(FestivalUiAction.OnEnableEditMode)
@@ -320,7 +306,6 @@ fun SchoolSearchBottomSheetPreview() {
             isSearchMode = false,
             isEditMode = false,
             isLikedFestivalDeleteDialogVisible = false,
-            isOnboardingCompleted = true,
             onFestivalUiAction = {},
         )
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -165,6 +165,7 @@ internal fun HomeScreen(
                             scheduleIndex = scheduleIndex,
                             likedFestivals = uiState.likedFestivals,
                             selectedDate = uiState.selectedDate,
+                            isDataReady = uiState.isDataReady,
                             isStarImageClicked = uiState.isStarImageClicked[scheduleIndex],
                             onHomeUiAction = onHomeUiAction,
                         )
@@ -236,6 +237,7 @@ fun FestivalScheduleItem(
     likedFestivals: ImmutableList<FestivalModel>,
     selectedDate: LocalDate,
     isStarImageClicked: ImmutableList<Boolean>,
+    isDataReady: Boolean,
     onHomeUiAction: (HomeUiAction) -> Unit,
 ) {
     Column {
@@ -256,11 +258,13 @@ fun FestivalScheduleItem(
             Column(
                 modifier = Modifier.width(172.dp),
             ) {
-                Text(
-                    text = "${festival.beginDate.toLocalDate().formatWithDayOfWeek()} - ${festival.endDate.toLocalDate().formatWithDayOfWeek()}",
-                    style = Content4,
-                    color = Color(0xFFC0C0C0),
-                )
+                if (isDataReady) {
+                    Text(
+                        text = "${festival.beginDate.toLocalDate().formatWithDayOfWeek()} - ${festival.endDate.toLocalDate().formatWithDayOfWeek()}",
+                        style = Content4,
+                        color = Color(0xFFC0C0C0),
+                    )
+                }
                 Spacer(modifier = Modifier.height(5.dp))
                 Text(
                     text = festival.festivalName + " Day " + (ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate) + 1),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -258,20 +258,20 @@ fun FestivalScheduleItem(
             Column(
                 modifier = Modifier.width(172.dp),
             ) {
+                Text(
+                    text = "${festival.beginDate.toLocalDate().formatWithDayOfWeek()} - ${festival.endDate.toLocalDate().formatWithDayOfWeek()}",
+                    style = Content4,
+                    color = Color(0xFFC0C0C0),
+                )
+                Spacer(modifier = Modifier.height(5.dp))
                 if (isDataReady) {
                     Text(
-                        text = "${festival.beginDate.toLocalDate().formatWithDayOfWeek()} - ${festival.endDate.toLocalDate().formatWithDayOfWeek()}",
-                        style = Content4,
-                        color = Color(0xFFC0C0C0),
+                        text = festival.festivalName + " Day " + (ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate) + 1),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = Title2,
                     )
                 }
-                Spacer(modifier = Modifier.height(5.dp))
-                Text(
-                    text = festival.festivalName + " Day " + (ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate) + 1),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = Title2,
-                )
                 Spacer(modifier = Modifier.height(7.dp))
                 Row {
                     Icon(

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -264,13 +264,21 @@ fun FestivalScheduleItem(
                     color = Color(0xFFC0C0C0),
                 )
                 Spacer(modifier = Modifier.height(5.dp))
-                if (isDataReady) {
+                Row {
                     Text(
-                        text = festival.festivalName + " Day " + (ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate) + 1),
+                        text = festival.festivalName + " Day ",
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         style = Title2,
                     )
+                    if (isDataReady) {
+                        Text(
+                            text = (ChronoUnit.DAYS.between(festival.beginDate.toLocalDate(), selectedDate) + 1).toString(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = Title2,
+                        )
+                    }
                 }
                 Spacer(modifier = Modifier.height(7.dp))
                 Row {

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -214,7 +214,6 @@ internal fun HomeScreen(
                 isEditMode = uiState.isEditMode,
                 isLikedFestivalDeleteDialogVisible = uiState.isLikedFestivalDeleteDialogVisible,
                 onFestivalUiAction = onFestivalUiAction,
-                isOnboardingCompleted = uiState.isFestivalOnboardingCompleted,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -26,4 +26,5 @@ data class HomeUiState(
     val isStarImageClicked: ImmutableList<ImmutableList<Boolean>> = persistentListOf(persistentListOf()),
     val isWeekMode: Boolean = false,
     val isFestivalOnboardingCompleted: Boolean = false,
+    val isDataReady: Boolean = true,
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -53,10 +53,12 @@ class HomeViewModel @Inject constructor(
     fun onHomeUiAction(action: HomeUiAction) {
         when (action) {
             is HomeUiAction.OnDateSelected -> {
+                _uiState.update {
+                    it.copy(isDataReady = false)
+                }
                 setSelectedDate(action.date)
                 getTodayFestivals(action.date.toString())
             }
-
             is HomeUiAction.OnAddAsLikedFestivalClick -> addLikeFestival(action.festivalTodayModel)
             is HomeUiAction.OnAddLikedFestivalClick -> setFestivalSearchBottomSheetVisible(true)
             is HomeUiAction.OnToggleStarImageClick -> toggleStarImageClicked(action.scheduleIndex, action.starIndex, action.flag)
@@ -148,6 +150,7 @@ class HomeViewModel @Inject constructor(
                             isStarImageClicked = festivals.map { festival ->
                                 List(festival.starInfo.size) { false }.toImmutableList()
                             }.toImmutableList(),
+                            isDataReady = true,
                         )
                     }
                 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -198,7 +198,6 @@ internal fun MapScreen(
                 isLikedFestivalDeleteDialogVisible = uiState.isLikedFestivalDeleteDialogVisible,
                 onFestivalUiAction = onFestivalUiAction,
                 isEditMode = uiState.isEditMode,
-                isOnboardingCompleted = uiState.isFestivalOnboardingCompleted,
             )
         }
         if (uiState.isPermissionDialogVisible) {

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/MenuScreen.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/MenuScreen.kt
@@ -327,7 +327,6 @@ fun MenuScreen(
                 isSearchMode = uiState.isSearchMode,
                 isEditMode = uiState.isEditMode,
                 onFestivalUiAction = onFestivalUiAction,
-                isOnboardingCompleted = uiState.isFestivalOnboardingCompleted,
             )
         }
     }


### PR DESCRIPTION
1. Day 값 표현 로직을 변경하여, 사용자가 날짜를 바꾼후 해당날짜의 축제정보를 서버에서 받은후 Day값을 비교하게해 Day -9등으로 보이던 문제를 수정했습니다
2. 부스 디테일과 메뉴에 필수값이 아닌 항목들에 Null처리를 해줬습니다. 이전에는 해당부분이 빠져있어 부스 전체의 정보를 제대로 표시하지 못하는 문제가 있었습니다(예, 플레이쿠라운드 부스의 메뉴사진이 없자 부스상세정보를 전부 표시하지 못함)
![KakaoTalk_20240515_230903803](https://github.com/Project-Unifest/unifest-android/assets/60922290/4af3581c-df94-4d80-a6aa-0abcaee173a5)

3. 바텀시트의 툴팁을 제거하고 간격을 좁혔는데, 이부분은 일단 작성만 해뒀습니다. 