### PR TITLE
[chore] build-logic config 앱 버전 관련 변수 제거

### DIFF
--- a/build-logic/src/main/kotlin/com/unifest/android/Config.kt
+++ b/build-logic/src/main/kotlin/com/unifest/android/Config.kt
@@ -1,11 +1,6 @@
 package com.unifest.android
 
 internal object ApplicationConfig {
-    const val MinSdk = 26
-    const val TargetSdk = 34
-    const val CompileSdk = 34
-    const val VersionCode = 9
-    const val VersionName = "0.1.8"
     val JavaVersion = org.gradle.api.JavaVersion.VERSION_17
     const val JavaVersionAsInt = 17
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "8"
-versionName = "0.1.7"
+versionCode = "9"
+versionName = "0.1.8"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION
앱 버전 관련 config 변수들 libs.versions.toml 로 이동되었습니다

해당 [PR](https://github.com/Project-Unifest/unifest-android/pull/176) 에서 변경된 사항이구요

이유는 앱에 전역에서 버전 정보를 가져올 수 있게 하기 위함입니다. 