### PR TITLE
[fix] 위치 권한 요청이 맵 화면 진입시 화면에 출력되지 않는 문제 해결 

### DIFF
--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -45,6 +45,7 @@ import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.extension.clickableSingle
 import com.unifest.android.core.common.utils.formatAsCurrency
 import com.unifest.android.core.designsystem.R
+import com.unifest.android.core.designsystem.component.LoadingWheel
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.component.ServerErrorDialog
@@ -169,6 +170,11 @@ fun BoothDetailScreen(
                 UnifestSnackBar(snackBarData = it)
             },
         )
+
+        if (uiState.isLoading) {
+            LoadingWheel(modifier = Modifier.fillMaxSize())
+        }
+
         if (uiState.isServerErrorDialogVisible) {
             ServerErrorDialog(
                 onRetryClick = { onAction(BoothUiAction.OnRetryClick(ErrorType.SERVER)) },

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -52,6 +52,9 @@ class BoothViewModel @Inject constructor(
 
     private fun getBoothDetail() {
         viewModelScope.launch {
+            _uiState.update {
+                it.copy(isLoading = true)
+            }
             boothRepository.getBoothDetail(boothId)
                 .onSuccess { booth ->
                     _uiState.update {
@@ -62,6 +65,9 @@ class BoothViewModel @Inject constructor(
                 .onFailure { exception ->
                     handleException(exception, this@BoothViewModel)
                 }
+            _uiState.update {
+                it.copy(isLoading = false)
+            }
         }
     }
 

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -109,14 +109,15 @@ internal fun MapRoute(
     val activity = context.findActivity()
 
     val locationPermissions = arrayOf(
-        Manifest.permission.ACCESS_FINE_LOCATION,
         Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
     )
 
     val locationPermissionResultLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
         onResult = { permissions ->
-            viewModel.onPermissionResult(isGranted = permissions.none { it.value })
+            val allPermissionsGranted = permissions.all { it.value }
+            viewModel.onPermissionResult(isGranted = allPermissionsGranted)
         },
     )
 
@@ -223,7 +224,6 @@ fun MapContent(
     Box {
         // TODO 같은 속성의 Marker 들만 클러스터링 되도록 구현
         // TODO 클러스터링 마커 커스텀
-        // TODO 지도 중앙 위치 조정
         NaverMap(
             cameraPositionState = cameraPositionState,
             locationSource = rememberFusedLocationSource(),

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -235,7 +235,7 @@ fun MapContent(
                 isLogoClickEnabled = false,
             ),
             properties = MapProperties(
-                locationTrackingMode = LocationTrackingMode.Follow,
+                locationTrackingMode = LocationTrackingMode.NoFollow,
             ),
         ) {
             PolygonOverlay(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -57,6 +57,8 @@ import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapProperties
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.MarkerState
@@ -231,6 +233,9 @@ fun MapContent(
                 isZoomControlEnabled = false,
                 isScaleBarEnabled = false,
                 isLogoClickEnabled = false,
+            ),
+            properties = MapProperties(
+                locationTrackingMode = LocationTrackingMode.Follow
             ),
         ) {
             PolygonOverlay(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -235,7 +235,7 @@ fun MapContent(
                 isLogoClickEnabled = false,
             ),
             properties = MapProperties(
-                locationTrackingMode = LocationTrackingMode.Follow
+                locationTrackingMode = LocationTrackingMode.Follow,
             ),
         ) {
             PolygonOverlay(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
@@ -22,6 +22,7 @@ import com.unifest.android.core.common.extension.noRippleClickable
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.Content1
+import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Title3
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.feature.map.viewmodel.MapUiAction
@@ -57,7 +58,7 @@ internal fun PermissionDialog(
                         .fillMaxWidth()
                         .padding(bottom = 16.dp),
                     color = Color(0xFF747479),
-                    style = Content1,
+                    style = Content2,
                 )
                 HorizontalDivider(color = Color(0xFFE3E5E9))
                 Text(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.extension.noRippleClickable
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.R
-import com.unifest.android.core.designsystem.theme.Content1
 import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Title3
 import com.unifest.android.core.designsystem.theme.UnifestTheme

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/PermissionDialog.kt
@@ -21,10 +21,11 @@ import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.extension.noRippleClickable
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.R
+import com.unifest.android.core.designsystem.theme.Content1
 import com.unifest.android.core.designsystem.theme.Title3
 import com.unifest.android.core.designsystem.theme.UnifestTheme
-import com.unifest.android.feature.map.viewmodel.PermissionDialogButtonType
 import com.unifest.android.feature.map.viewmodel.MapUiAction
+import com.unifest.android.feature.map.viewmodel.PermissionDialogButtonType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,6 +57,7 @@ internal fun PermissionDialog(
                         .fillMaxWidth()
                         .padding(bottom = 16.dp),
                     color = Color(0xFF747479),
+                    style = Content1,
                 )
                 HorizontalDivider(color = Color(0xFFE3E5E9))
                 Text(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -46,11 +46,18 @@ class MapViewModel @Inject constructor(
     val uiEvent: Flow<MapUiEvent> = _uiEvent.receiveAsFlow()
 
     init {
+        requestLocationPermission()
         searchSchoolName()
         getAllFestivals()
         checkMapOnboardingCompletion()
         checkFestivalOnboardingCompletion()
         observeLikedFestivals()
+    }
+
+    private fun requestLocationPermission() {
+        viewModelScope.launch {
+            _uiEvent.send(MapUiEvent.RequestLocationPermission)
+        }
     }
 
     fun onPermissionResult(isGranted: Boolean) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "9"
-versionName = "0.1.8"
+versionCode = "10"
+versionName = "1.0.0"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION
feat)
- 위치 권한 요청 부활
- 위치 권한 요청이 허락될 경우 ~~LocationTrackingMode.Follow~~ (지도에 내 위치, 이동 방향이 보이며, 실시간으로 위치가 갱신) 활성화
- NoFollow 로 설정 (Follow 로 하게 될 경우, 지도 자체가 내 위치로 이동함, 내 위치는 추적하되 지도는 이동하지 않는 모드로 변경)

style)
- 부스 상세 화면 진입시 로딩 화면 추가 


- MVP 구현해야할 부분은 다 구현된 것 같고, 눈에 보이는 버그가 당장은 보이지 않아, app version 은 정식 버전인 1.0.0 버전으로 올렸습니다. 