### PR TITLE
[fix] QA 3차 

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
 
     <!--    Menu    -->
     <string name="menu_title">메뉴</string>
-    <string name="menu_my_liked_festival">나의 관심 학교</string>
+    <string name="menu_my_liked_festival">나의 관심 축제</string>
     <string name="menu_add">추가하기 ></string>
     <string name="menu_liked_booth">관심 부스</string>
     <string name="menu_watch_more">더보기 ></string>

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -86,7 +86,9 @@ internal fun MainScreen(
                 visible = navigator.shouldShowBottomBar(),
                 tabs = MainTab.entries.toImmutableList(),
                 currentTab = navigator.currentTab,
-                onTabSelected = { navigator.navigate(it) },
+                onTabSelected = {
+                    navigator.navigate(it)
+                },
             )
         },
         snackbarHost = {
@@ -169,7 +171,11 @@ private fun MainBottomBar(
                         MainBottomBarItem(
                             tab = tab,
                             selected = tab == currentTab,
-                            onClick = { onTabSelected(tab) },
+                            onClick = {
+                                if (tab != currentTab) {
+                                    onTabSelected(tab)
+                                }
+                            },
                         )
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "10"
-versionName = "1.0.0"
+versionCode = "11"
+versionName = "1.0.1"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION
fix)
바텀 네비게이션 중복 클릭 방지 

style)
메뉴 화면 나의 관심 학교 -> 나의 관심 축제로 네이밍 변경 

P.S
연예인 정보를 롱 클릭하였을때, 확대해서 볼 수 있는 기능을 추가하고 싶은데 서버에 저장된 사진 규격이 문제네요..
사진 거 뭐 많아봤자 50개도 안되는데 작업하면 좋을것같은데, 아니면 제가 직접해두 되구,, 아쉬운 부분입니다   