### PR TITLE
[style] 앱 내에 텍스트 길이 제한 및 최대 줄 수 조정

### DIFF
--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -65,6 +67,7 @@ import com.unifest.android.core.designsystem.theme.MenuPrice
 import com.unifest.android.core.designsystem.theme.MenuTitle
 import com.unifest.android.core.designsystem.theme.Title2
 import com.unifest.android.core.designsystem.theme.Title4
+import com.unifest.android.core.designsystem.theme.Title5
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.MenuModel
@@ -322,10 +325,17 @@ fun BoothDescription(
     onAction: (BoothUiAction) -> Unit,
 ) {
     Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+        val configuration = LocalConfiguration.current
+        val maxWidth = remember(configuration) {
+            val screenWidth = configuration.screenWidthDp.dp - 40.dp
+            screenWidth * (2 / 3f)
+        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = name,
-                modifier = Modifier.alignByBaseline(),
+                modifier = Modifier
+                    .widthIn(max = maxWidth)
+                    .alignByBaseline(),
                 style = BoothTitle1,
             )
             Spacer(modifier = Modifier.width(5.dp))
@@ -364,7 +374,10 @@ fun BoothDescription(
             onClick = { onAction(BoothUiAction.OnCheckLocationClick) },
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text(text = stringResource(id = R.string.booth_check_locaiton))
+            Text(
+                text = stringResource(id = R.string.booth_check_locaiton),
+                style = Title5,
+            )
         }
     }
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -495,6 +495,8 @@ fun BoothItem(
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = boothInfo.location,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             style = Title5,
                         )
                     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "11"
-versionName = "1.0.1"
+versionCode = "12"
+versionName = "1.0.2"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION
Map 화면)
- HorizontalPager 내에 아이템의 Location Text 의 길이 제한을 1줄로 하여, 글자 길이에 따른 아이템의 높이가 변화되지 않고, 고정되도록 수정

부스 상세 화면)
- 부스 제목이 화면 전체 가로길이의 2/3 가 넘지않도록 길이 제한
- fontStyle 이 적용되지 않은 Text fontStyle 적용 