### PR TITLE
[design] 축제 개수별 색 변경

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_calender_left.xml
+++ b/core/designsystem/src/main/res/drawable/ic_calender_left.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="14.997778dp" android:viewportHeight="17" android:viewportWidth="9" android:width="7.94dp">
+      
+    <path android:fillColor="#00000000" android:pathData="M8,1L1.191,8.295C1.083,8.411 1.083,8.589 1.191,8.705L8,16" android:strokeColor="#767676" android:strokeLineCap="round" android:strokeWidth="1.5"/>
+    
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_calender_right.xml
+++ b/core/designsystem/src/main/res/drawable/ic_calender_right.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="15dp" android:viewportHeight="17" android:viewportWidth="9" android:width="7.9411764dp">
+      
+    <path android:fillColor="#00000000" android:pathData="M1,16L7.809,8.705C7.917,8.589 7.917,8.411 7.809,8.295L1,1" android:strokeColor="#767676" android:strokeLineCap="round" android:strokeWidth="1.5"/>
+    
+</vector>

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -58,7 +56,6 @@ import com.kizitonwose.calendar.core.yearMonth
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.BoothTitle0
-import com.unifest.android.core.designsystem.theme.BoothTitle1
 import com.unifest.android.core.designsystem.theme.Content6
 import com.unifest.android.core.designsystem.theme.Title5
 import com.unifest.android.core.designsystem.theme.MainColor
@@ -196,7 +193,7 @@ private fun CalendarNavigationIcon(
         .clip(CircleShape)
         .clickable(
             role = Role.Button,
-            onClick = onClick
+            onClick = onClick,
         ),
 ) {
     Icon(

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -304,7 +304,12 @@ fun ColorCircleWithText(color: Color, text: String) {
                 .background(color),
         )
         Spacer(modifier = Modifier.width(4.dp))
-        Text(text = text, style = Content6)
+        Text(
+            text = text,
+            style = Content6,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -190,15 +191,13 @@ private fun CalendarNavigationIcon(
     onClick: () -> Unit,
 ) = Box(
     modifier = Modifier
-        .fillMaxHeight()
-        .aspectRatio(1f)
-        .clip(shape = CircleShape)
+        .size(20.dp)
         .clickable(role = Role.Button, onClick = onClick),
 ) {
     Icon(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(4.dp)
+            .height(15.dp)
+            .width(8.dp)
             .align(Alignment.Center),
         imageVector = icon,
         contentDescription = contentDescription,
@@ -219,7 +218,7 @@ fun MonthAndWeekCalendarTitle(
     val coroutineScope = rememberCoroutineScope()
     if (!isWeekMode) {
         SimpleCalendarTitle(
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier.padding(start = 20.dp, end = 7.dp, top = 20.dp, bottom = 20.dp),
             currentMonth = currentMonth,
             currentYear = currentYear,
             goToPrevious = {
@@ -262,10 +261,11 @@ fun SimpleCalendarTitle(
             .height(40.dp)
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Row(
             modifier = Modifier.weight(1f),
-            verticalAlignment = Alignment.Bottom,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = "${currentYear}년 ${currentMonth.displayText()}",
@@ -280,12 +280,13 @@ fun SimpleCalendarTitle(
             ColorCircleWithText(color = Color(0xFFFF3939), text = "3개 이상")
         }
         CalendarNavigationIcon(
-            icon = ImageVector.vectorResource(id = R.drawable.ic_chevron_left),
+            icon = ImageVector.vectorResource(id = R.drawable.ic_calender_left),
             contentDescription = "Previous",
             onClick = goToPrevious,
         )
+        Spacer(modifier = Modifier.width(10.dp))
         CalendarNavigationIcon(
-            icon = ImageVector.vectorResource(id = R.drawable.ic_chevron_right),
+            icon = ImageVector.vectorResource(id = R.drawable.ic_calender_right),
             contentDescription = "Next",
             onClick = goToNext,
         )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -58,6 +58,7 @@ import com.kizitonwose.calendar.core.yearMonth
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.BoothTitle0
+import com.unifest.android.core.designsystem.theme.BoothTitle1
 import com.unifest.android.core.designsystem.theme.Content6
 import com.unifest.android.core.designsystem.theme.Title5
 import com.unifest.android.core.designsystem.theme.MainColor
@@ -192,7 +193,11 @@ private fun CalendarNavigationIcon(
 ) = Box(
     modifier = Modifier
         .size(20.dp)
-        .clickable(role = Role.Button, onClick = onClick),
+        .clip(CircleShape)
+        .clickable(
+            role = Role.Button,
+            onClick = onClick
+        ),
 ) {
     Icon(
         modifier = Modifier
@@ -269,10 +274,10 @@ fun SimpleCalendarTitle(
         ) {
             Text(
                 text = "${currentYear}년 ${currentMonth.displayText()}",
-                style = BoothTitle0,
+                style = BoothTitle1,
                 textAlign = TextAlign.Start,
             )
-            Spacer(modifier = Modifier.width(4.dp))
+            Spacer(modifier = Modifier.width(6.dp))
             ColorCircleWithText(color = Color(0xFF1FC0BA), text = "1개")
             Spacer(modifier = Modifier.width(4.dp))
             ColorCircleWithText(color = Color(0xFFFF8A1F), text = "2개")

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -223,7 +223,7 @@ fun MonthAndWeekCalendarTitle(
     val coroutineScope = rememberCoroutineScope()
     if (!isWeekMode) {
         SimpleCalendarTitle(
-            modifier = Modifier.padding(start = 20.dp, end = 7.dp, top = 20.dp, bottom = 20.dp),
+            modifier = Modifier.padding(start = 18.dp, end = 7.dp, top = 20.dp, bottom = 20.dp),
             currentMonth = currentMonth,
             currentYear = currentYear,
             goToPrevious = {
@@ -274,7 +274,7 @@ fun SimpleCalendarTitle(
         ) {
             Text(
                 text = "${currentYear}년 ${currentMonth.displayText()}",
-                style = BoothTitle1,
+                style = BoothTitle0,
                 textAlign = TextAlign.Start,
             )
             Spacer(modifier = Modifier.width(6.dp))

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -342,17 +342,18 @@ fun Day(
         !(day.isBefore(beginDate) || day.isAfter(endDate))
     }
 
-    Column(
-        modifier = Modifier.clickable(
-            enabled = isSelectable,
-            showRipple = false,
-            onClick = { onClick(day) },
-        ),
+    Box(
+        modifier = Modifier
+            .clickable(
+                enabled = isSelectable,
+                showRipple = false,
+                onClick = { onClick(day) },
+            ),
     ) {
         Box(
             modifier = Modifier
                 .aspectRatio(1f) // This is important for square-sizing!
-                .padding(10.dp)
+                .padding(16.dp)
                 .clip(CircleShape)
                 .background(color = if (isSelected) MainColor else Color.Transparent)
                 .then(
@@ -382,10 +383,10 @@ fun Day(
             }
             Box(
                 modifier = Modifier
-                    .size(7.dp)
+                    .size(9.dp)
                     .clip(CircleShape)
                     .background(festivalDotColor)
-                    .align(Alignment.CenterHorizontally),
+                    .align(Alignment.BottomCenter),
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kizitonwose.calendar.compose.CalendarState

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/Calendar.kt
@@ -115,7 +115,7 @@ fun Calendar(
                     dayContent = { day ->
                         val isSelectable = day.position == DayPosition.MonthDate
                         Day(
-                            day.date,
+                            day = day.date,
                             isSelected = isSelectable && selectedDate == day.date,
                             isSelectable = isSelectable,
                             onClick = { newSelectedDate ->
@@ -132,7 +132,7 @@ fun Calendar(
                     dayContent = { day ->
                         val isSelectable = day.position == WeekDayPosition.RangeDate
                         Day(
-                            day.date,
+                            day = day.date,
                             isSelected = isSelectable && selectedDate == day.date,
                             isSelectable = isSelectable,
                             onClick = { newSelectedDate ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "14"
-versionName = "1.0.4"
+versionCode = "15"
+versionName = "1.0.5"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION
<img width="745" alt="스크린샷 2024-05-21 140906" src="https://github.com/Project-Unifest/unifest-android/assets/60922290/a41543f3-4fb4-4cba-87d6-72660a7b75ef">

기존 디자인 2번에서 3번 시안으로 변경