### PR TITLE
[fix] ToolTip 및 TextField 관련 이슈 해결 

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
@@ -67,7 +67,11 @@ fun SearchTextField(
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
             value = searchText,
-            onValueChange = updateSearchText,
+            onValueChange = {
+                if (it.text.length <= 20) {
+                    updateSearchText(it)
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(
@@ -76,6 +80,7 @@ fun SearchTextField(
                     keyboardController?.hide()
                 },
             ),
+            singleLine = true,
             textStyle = TextStyle(color = textColor),
             cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
             decorationBox = { innerTextField ->
@@ -150,9 +155,14 @@ fun FestivalSearchTextField(
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
             value = searchText,
-            onValueChange = updateSearchText,
+            onValueChange = {
+                if (it.text.length <= 20) {
+                    updateSearchText(it)
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            singleLine = true,
             textStyle = TextStyle(color = textColor),
             cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
             decorationBox = { innerTextField ->

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/Tooltip.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/Tooltip.kt
@@ -32,6 +32,7 @@ import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.Content5
 import com.unifest.android.core.designsystem.theme.Title1
 import com.unifest.android.core.designsystem.theme.UnifestTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -80,6 +81,7 @@ fun ToolTip(
         content()
         LaunchedEffect(key1 = Unit) {
             scope.launch {
+                delay(500)
                 balloonWindow.awaitAlignEnd()
             }
         }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/Tooltip.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/Tooltip.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.skydoves.balloon.ArrowOrientation
+import com.skydoves.balloon.ArrowOrientationRules
 import com.skydoves.balloon.BalloonAnimation
 import com.skydoves.balloon.BalloonSizeSpec
 import com.skydoves.balloon.compose.Balloon
@@ -48,6 +49,7 @@ fun ToolTip(
         setArrowSize(10)
         setArrowPosition(arrowPosition)
         setArrowOrientation(arrowOrientation)
+        setArrowOrientationRules(ArrowOrientationRules.ALIGN_FIXED)
         setWidth(BalloonSizeSpec.WRAP)
         setHeight(BalloonSizeSpec.WRAP)
         setPadding(9)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ versionCode = "17"
 versionName = "1.0.7"
 packageName = "com.unifest.android"
 
-android-gradle-plugin = "8.6.0"
+android-gradle-plugin = "8.5.1"
 kotlin-core = "2.0.20"
 gradle-dependency-handler-extensions = "1.1.0"
 


### PR DESCRIPTION
fix)
TextField
 singleLine 적용, Textfield 텍스트 maxLength 제한(20자) 
-> 텍스트가 길어지면 clear icon 을 밀어 텍스트 필드 바깥으로 텍스트가 빠져나가는 문제 해결

ToolTip
Balloon ToolTip 이 좌우, 상하 반전되는 문제를 해결(`setArrowOrientationRules(ArrowOrientationRules.ALIGN_FIXED)`)
해당 옵션을 적용하면, 공간이 협소해도 기존 ArrowOrientation(말풍선 꼬리 위치) 이 유지됩니다. default 옵션인 ALIGN_ANCHORED 로 설정이 되어 있어서, 기존의 ToolTip 에서 발생했던 문제가 발생한 것이었습니다... 문서를 꼼꼼히 읽어봤어야 했는데...(개인적으론 fixed 가 default 면 좋을 것 같긴합니다.)
https://github.com/skydoves/Balloon/issues/692

Balloon 렌더링 지연 시간 적용
Api 호출을 통해 학교명을 가져오는데, 해당 data 가 아직 들어오지 않았을 때("" 빈값) 바로 옆에 툴팁이 렌더링되고, 학교명 데이터를 받아온 후, 이미 렌더링된 툴팁에 의해 학교명이 가려지는 문제 발생하였는데. 500ms 딜레이 부여하여 렌더링 되게 하여, 학교명이 툴팁에 의해 가려지는 문제를 해결하였습니다. 
![image](https://github.com/user-attachments/assets/2f73eb5b-52c5-4c3c-9d6e-362ee19e8fc0)

