### PR TITLE
[style] 업데이트 전 UI 관련 디테일 수정 

### DIFF
--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -180,7 +182,7 @@ fun WaitingPinDialog(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun WaitingDialog(
     boothName: String,
@@ -314,8 +316,8 @@ fun WaitingDialog(
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier.padding(horizontal = 16.dp),
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                FlowRow(
+                    verticalArrangement = Arrangement.Center,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Icon(

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -139,7 +140,6 @@ fun WaitingPinDialog(
                 Spacer(modifier = Modifier.height(10.dp))
                 AnimatedContent(targetState = isWrongPinInserted) { isWrongPinInserted ->
                     Row(
-                        modifier = Modifier.height(24.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Spacer(modifier = Modifier.width(14.dp))

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
@@ -68,7 +68,7 @@ fun FestivalSearchBottomSheet(
 //    )
     val bottomSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
-        confirmValueChange = { it != SheetValue.Hidden },
+        // confirmValueChange = { it != SheetValue.Hidden },
     )
 
     ModalBottomSheet(
@@ -98,7 +98,6 @@ fun FestivalSearchBottomSheet(
         windowInsets = WindowInsets(top = 0),
         modifier = Modifier
             .fillMaxHeight()
-            .background(MaterialTheme.colorScheme.surface)
             .padding(top = 18.dp),
     ) {
         Column(

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState


### PR DESCRIPTION
style)
웨이팅 다이얼로그)
텍스트의 높이를 제한하여, 핀번호 입력 에러 문구 짤리는 문제 해결 -> 다이얼로그 크기가 늘어나도, 문구가 2줄이 넘어갈때 잘리지 않는게 더 중요
개인정보처리방침 문구 의도치 않게 개행되는 이슈 해결

Before)
![image](https://github.com/user-attachments/assets/541e72b0-f58c-4711-a256-222fee31895e)

After)
![image](https://github.com/user-attachments/assets/2bae689f-92e7-463e-8aa4-fbf34cbbe04b)
FlowRow 를 도입하여 공간이 부족할 경우 다음줄로 개행되도록 수정하였습니다.



축제 바텀시트)
바텀시트 뒤에 영역이 보이도록, 드래그 핸들을 잡고 내릴시 바텀시트가 내려가도록 롤백 
