### PR TITLE
[fix] QA: 학교명을 통한 API 호출 로직 수정

### DIFF
--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
@@ -124,7 +124,7 @@ class FestivalViewModel @Inject constructor(
 
     private fun setRecentLikedFestival(schoolName: String) {
         viewModelScope.launch {
-            if (schoolName == likedFestivalRepository.getRecentLikedFestival()) {
+            if (schoolName == "한국교통대학교") {
                 // likedFestivalRepository.setRecentLikedFestival(schoolName)
                 setFestivalSearchBottomSheetVisible(false)
                 _uiEvent.send(FestivalUiEvent.NavigateBack)

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -184,7 +184,7 @@ class IntroViewModel @Inject constructor(
             _uiState.value.selectedFestivals.forEach { festival ->
                 likedFestivalRepository.insertLikedFestivalAtSearch(festival)
             }
-            likedFestivalRepository.setRecentLikedFestival("한국교통대")
+            likedFestivalRepository.setRecentLikedFestival("한국교통대학교")
             likedFestivalRepository.setRecentLikedFestivalId(2L)
             onboardingRepository.completeIntro(true)
             _uiEvent.send(IntroUiEvent.NavigateToMain)

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -152,7 +152,7 @@ class MapViewModel @Inject constructor(
 
     private fun searchSchoolName() {
         viewModelScope.launch {
-            festivalRepository.searchSchool(likedFestivalRepository.getRecentLikedFestival())
+            festivalRepository.searchSchool("한국교통대학교")
                 .onSuccess { festivals ->
                     if (festivals.isNotEmpty()) {
                         _uiState.update {

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -193,7 +193,7 @@ class MenuViewModel @Inject constructor(
 
     private fun setRecentLikedFestival(schoolName: String) {
         viewModelScope.launch {
-            if (schoolName == likedFestivalRepository.getRecentLikedFestival()) {
+            if (schoolName == "한국교통대학교") {
                 // likedFestivalRepository.setRecentLikedFestival(schoolName)
                 _uiEvent.send(MenuUiEvent.NavigateBack)
             } else {

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -51,7 +51,7 @@ class SplashViewModel @Inject constructor(
 
     private fun setRecentLikedFestival() {
         viewModelScope.launch {
-            likedFestivalRepository.setRecentLikedFestival("한국교통대")
+            likedFestivalRepository.setRecentLikedFestival("한국교통대학교")
             likedFestivalRepository.setRecentLikedFestivalId(2L)
             _uiEvent.send(SplashUiEvent.NavigateToMain)
         }
@@ -65,7 +65,7 @@ class SplashViewModel @Inject constructor(
                 token?.let {
                     Timber.d("New FCM token: $it")
                     messagingRepository.setFCMToken(it)
-                    // 한국교통대로 고정
+                    // 한국교통대학교로 고정
                     setRecentLikedFestival()
                 }
             } catch (e: Exception) {

--- a/feature/stamp/src/main/res/values/strings.xml
+++ b/feature/stamp/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="stamp_qr_scan_description1">카메라를 조준선에 맞춰주세요!</string>
     <string name="stamp_qr_scan_description2">※ 하나의 부스에서는 하나의 스탬프만 받을 수 있습니다.</string>
     <string name="stamp_booth">스탬프 가능 부스</string>
-    <string name="stamp_register_completed">스탬프가 등록 되었습니다.</string>
-    <string name="stamp_register_failed">스탬프 등록을 실패하였습니다.</string>
+    <string name="stamp_register_completed">스탬프가 성공적으로 등록 되었습니다.</string>
+    <string name="stamp_register_failed">올바르지 않은 QR코드입니다. 운영자에 문의바랍니다.</string>
 
 </resources>


### PR DESCRIPTION
fix)
- 앱 시작시 로컬 디비에서 최근에 관심 축제로 추가한 학교를 가져와 API 를 호출하는 것이 아닌, 고정된 문자열을 통해 호출
- 관심 축제에서 삭제했을 경우 API 호출시 발생하는 문제를 방지

QA 를 통해 발견된 문제들이 해결되었는지 확인 후 approve - merge 하도록 하겠습니다.(이 브랜치에 미처 발견하지 못한 버그들에 대한 이슈 해결 커밋도 추가하면 될 것 같아요) 