### PR TITLE
[fix] #287 QRScan NumberFormatException 대응

### DIFF
--- a/core/common/src/main/kotlin/com/unifest/android/core/common/HandleQRException.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/HandleQRException.kt
@@ -35,6 +35,11 @@ fun handleException(exception: Throwable, actions: QRErrorHandlerActions) {
             actions.setServerErrorDialogVisible(true)
         }
 
+        is NumberFormatException -> {
+            Timber.e(exception)
+            actions.showErrorMessage(UiText.StringResource(R.string.not_found_stamp))
+        }
+
         else -> {
             Timber.e(exception)
         }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroActivity.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.unifest.android.core.designsystem.theme.DarkGrey100
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.feature.navigator.MainNavigator

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/QRScanViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/QRScanViewModel.kt
@@ -66,7 +66,12 @@ class QRScanViewModel @Inject constructor(
     fun scan(entryCode: String) {
         Timber.d("스캔 결과: $entryCode")
         viewModelScope.launch {
-            _uiEvent.send(QRScanUiEvent.ScanSuccess(entryCode))
+            val boothId = entryCode.toLongOrNull()
+            if (boothId != null) {
+                _uiEvent.send(QRScanUiEvent.ScanSuccess(entryCode))
+            } else {
+                handleException(NumberFormatException("Invalid QR code: $entryCode"), this@QRScanViewModel)
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
 versionCode = "25"
-versionName = "1.2.4"
+versionName = "1.2.5"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.5.2"


### PR DESCRIPTION
이슈)
QRScan 결과로 얻어지는 entryCode 가 boothId 의 타입인 Long 타입 의외에 다른 타입이 얻어지는 경우(ex String, Link 등을 스캔하는 경우)
NumberFormatException 이 발생하여, 앱의 크래시가 발생하는 문제 발생

위의 문제를 해결하였습니다.