### PR TITLE
[feat] FCM 토큰 등록 api 연동 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,6 @@ allprojects {
     }
 }
 
-apply {
-    from("gradle/projectDependencyGraph.gradle")
-}
+// apply {
+//     from("gradle/projectDependencyGraph.gradle")
+// }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepository.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepository.kt
@@ -1,6 +1,9 @@
 package com.unifest.android.core.data.repository
 
+import com.unifest.android.core.network.response.FCMTokenResponse
+
 interface MessagingRepository {
     suspend fun refreshFCMToken(): String?
-    suspend fun setFCMToken(token: String)
+    suspend fun setFCMToken(fcmToken: String)
+    suspend fun registerFCMToken(fcmToken: String): Result<FCMTokenResponse>
 }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepositoryImpl.kt
@@ -44,7 +44,7 @@ class MessagingRepositoryImpl @Inject constructor(
             RegisterFCMTokenRequest(
                 deviceId = deviceId,
                 fcmToken = fcmToken,
-            )
+            ),
         )
     }
 }

--- a/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/unifest/android/core/data/repository/MessagingRepositoryImpl.kt
@@ -1,15 +1,23 @@
 package com.unifest.android.core.data.repository
 
+import android.content.Context
 import com.google.firebase.messaging.FirebaseMessaging
+import com.unifest.android.core.common.getDeviceId
+import com.unifest.android.core.data.util.runSuspendCatching
 import com.unifest.android.core.datastore.TokenDataSource
+import com.unifest.android.core.network.request.RegisterFCMTokenRequest
+import com.unifest.android.core.network.service.UnifestService
+import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 class MessagingRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val firebaseMessaging: FirebaseMessaging,
     private val tokenDataSource: TokenDataSource,
+    private val service: UnifestService,
 ) : MessagingRepository {
     override suspend fun refreshFCMToken(): String? = suspendCoroutine { continuation ->
         firebaseMessaging.token.addOnCompleteListener { task ->
@@ -26,7 +34,17 @@ class MessagingRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun setFCMToken(token: String) {
-        tokenDataSource.setFCMToken(token)
+    override suspend fun setFCMToken(fcmToken: String) {
+        tokenDataSource.setFCMToken(fcmToken)
+    }
+
+    override suspend fun registerFCMToken(fcmToken: String) = runSuspendCatching {
+        val deviceId = getDeviceId(context)
+        service.registerFCMToken(
+            RegisterFCMTokenRequest(
+                deviceId = deviceId,
+                fcmToken = fcmToken,
+            )
+        )
     }
 }

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/request/RegisterFCMTokenRequest.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/request/RegisterFCMTokenRequest.kt
@@ -1,0 +1,12 @@
+package com.unifest.android.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterFCMTokenRequest(
+    @SerialName("deviceId")
+    val deviceId: String,
+    @SerialName("fcmToken")
+    val fcmToken: String,
+)

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/FCMTokenResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/FCMTokenResponse.kt
@@ -1,0 +1,14 @@
+package com.unifest.android.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FCMTokenResponse(
+    @SerialName("code")
+    val code: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: String,
+)

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/service/UnifestService.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/service/UnifestService.kt
@@ -4,6 +4,7 @@ import com.unifest.android.core.network.request.BoothWaitingRequest
 import com.unifest.android.core.network.request.CheckPinValidationRequest
 import com.unifest.android.core.network.request.LikeBoothRequest
 import com.unifest.android.core.network.request.LikedFestivalRequest
+import com.unifest.android.core.network.request.RegisterFCMTokenRequest
 import com.unifest.android.core.network.request.RegisterStampRequest
 import com.unifest.android.core.network.request.WaitingRequest
 import com.unifest.android.core.network.response.booth.AllBoothsResponse
@@ -16,6 +17,7 @@ import com.unifest.android.core.network.response.booth.LikedBoothsResponse
 import com.unifest.android.core.network.response.MyWaitingResponse
 import com.unifest.android.core.network.response.booth.PopularBoothsResponse
 import com.unifest.android.core.network.response.CollectedStampCountResponse
+import com.unifest.android.core.network.response.FCMTokenResponse
 import com.unifest.android.core.network.response.WaitingResponse
 import com.unifest.android.core.network.response.booth.StampBoothsResponse
 import retrofit2.http.Body
@@ -142,4 +144,10 @@ interface UnifestService {
     suspend fun getStampEnabledBoothList(
         @Path("festival-id") festivalId: Long,
     ): StampBoothsResponse
+
+    // FCM 토큰 등록
+    @PUT("fcm-token")
+    suspend fun registerFCMToken(
+        @Body registerFCMTokenRequest: RegisterFCMTokenRequest,
+    ): FCMTokenResponse
 }

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashScreen.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashScreen.kt
@@ -37,6 +37,7 @@ internal fun SplashRoute(
     LaunchedEffect(key1 = shouldUpdate) {
         if (shouldUpdate == false) {
             viewModel.refreshFCMToken()
+            navigateToMain()
         }
     }
 

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashScreen.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashScreen.kt
@@ -78,13 +78,6 @@ fun SplashScreen(
     uiState: SplashUiState,
     onAction: (SplashUiAction) -> Unit,
 ) {
-    if (uiState.isLoading) {
-        LoadingWheel(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
-        )
-    }
     if (shouldUpdate == true) {
         AppUpdateDialog(
             onDismissRequest = { onAction(SplashUiAction.OnUpdateDismissClick) },

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -61,10 +61,11 @@ class SplashViewModel @Inject constructor(
     fun refreshFCMToken() {
         viewModelScope.launch {
             try {
-                val token = messagingRepository.refreshFCMToken()
-                token?.let {
-                    Timber.d("New FCM token: $it")
-                    messagingRepository.setFCMToken(it)
+                val fcmToken = messagingRepository.refreshFCMToken()
+                fcmToken?.let { token ->
+                    Timber.d("New FCM token: $token")
+                    messagingRepository.registerFCMToken(token)
+                    messagingRepository.setFCMToken(token)
                     // 한국교통대학교로 고정
                     setRecentLikedFestival()
                 }

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -64,7 +64,11 @@ class SplashViewModel @Inject constructor(
                 fcmToken?.let { token ->
                     Timber.d("New FCM token: $token")
                     messagingRepository.registerFCMToken(token)
-                    messagingRepository.setFCMToken(token)
+                        .onSuccess {
+                            messagingRepository.setFCMToken(token)
+                        }.onFailure { exception ->
+                            Timber.e(exception, "Error registering FCM token")
+                        }
                     // 한국교통대학교로 고정
                     setRecentLikedFestival()
                 }

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -53,7 +53,6 @@ class SplashViewModel @Inject constructor(
         viewModelScope.launch {
             likedFestivalRepository.setRecentLikedFestival("한국교통대학교")
             likedFestivalRepository.setRecentLikedFestivalId(2L)
-            _uiEvent.send(SplashUiEvent.NavigateToMain)
         }
     }
 


### PR DESCRIPTION
feat)
- FCM Token 등록 API 연동 

refactor)
- 앱 진입시 실행되는 함수 책임 분리 

비고)
앱 진입시 WIFI 또는 데이터 연결이 되어있지 않은 경우, FCM 토큰 발급 및 서버로의 등록이 실패하여 앱내에 FCM 토큰을 사용하는 다른 API 의 동작에서도 문제가 생길 수 있으므로, 해당 플로우로의 진입을 막을 장치가 필요할 것으로 보입니다.(팝업을 띄우고 종료, 스낵바를 띄우고 종료)
해당 기획 및 UI 가 추가 되면 따로 브랜치 파서 작업하도록 하겠습니다.