### PR TITLE
[fix] 웨이팅 화면 COMPLETED 상태의 웨이팅 아이템 filter 처리 

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -24,7 +24,7 @@ jobs:
                     java-version: 17
 
             -   name: Generate unifest.jks
-                run: echo '${{ secrets.UNIFEST_KEYSTORE }}' | base64 --d > ./app/unifest.jks
+                run: echo '${{ secrets.UNIFEST_KEYSTORE }}' | base64 -d > ./app/unifest.jks
 
             -   name: Generate secrets.properties
                 run: |
@@ -39,7 +39,7 @@ jobs:
                     echo '${{ secrets.KEYSTORE_PROPERTIES }}' >> ./keystore.properties
 
             -   name: Generate google-services.json
-                run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 --d > ./app/google-services.json
+                run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 -d > ./app/google-services.json
 
             -   name: Extract Version Name
                 run: echo "##[set-output name=version;]v$(echo '${{ github.event.pull_request.title }}' | grep -oP 'release v\K[0-9]+\.[0-9]+\.[0-9]+')"

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -45,15 +45,15 @@ jobs:
                 run: echo "##[set-output name=version;]v$(echo '${{ github.event.pull_request.title }}' | grep -oP 'release v\K[0-9]+\.[0-9]+\.[0-9]+')"
                 id: extract_version
 
-            -   name: Build Release APK
+            -   name: Build Debug APK
                 run: |
-                    ./gradlew :app:assembleRelease
+                    ./gradlew :app:assembleDebug
 
-            -   name: Upload Release Build to Artifacts
+            -   name: Upload Debug Build to Artifacts
                 uses: actions/upload-artifact@v4
                 with:
-                    name: release-artifacts
-                    path: app/build/outputs/apk/release/
+                    name: debug-artifacts
+                    path: app/build/outputs/apk/debug/
                     if-no-files-found: error
 
             -   name: Create Github Release
@@ -62,8 +62,6 @@ jobs:
                     tag_name: ${{ steps.extract_version.outputs.version }}
                     release_name: ${{ steps.extract_version.outputs.version }}
                     generate_release_notes: true
-                    files: |
-                        app/build/outputs/apk/release/app-release.apk
 
             -   name: Upload artifact to Firebase App Distribution
                 uses: wzieba/Firebase-Distribution-Github-Action@v1
@@ -71,4 +69,4 @@ jobs:
                     appId: ${{secrets.FIREBASE_APP_ID}}
                     serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
                     groups: testers
-                    file: app/build/outputs/apk/release/app-release.apk
+                    file: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -50,6 +50,9 @@ jobs:
             -   name: Generate google-services.json
                 run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 --d > ./app/google-services.json
 
+            -   name: Generate debug.keystore
+                run: echo '${{ secrets.DEBUG_KEYSTORE }}' | base64 --d > ./debug.keystore
+
             -   name: Code style checks
                 run: |
                     ./gradlew ktlintCheck detekt -PexcludeModules=baselineprofile

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -48,10 +48,10 @@ jobs:
                     echo '${{ secrets.KEYSTORE_PROPERTIES }}' >> ./keystore.properties
 
             -   name: Generate google-services.json
-                run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 --d > ./app/google-services.json
+                run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 -d > ./app/google-services.json
 
             -   name: Generate debug.keystore
-                run: echo '${{ secrets.DEBUG_KEYSTORE }}' | base64 --d > ./debug.keystore
+                run: echo '${{ secrets.DEBUG_KEYSTORE }}' | base64 -d > ./debug.keystore
 
             -   name: Code style checks
                 run: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ app/.idea/
 
 # Keystore files
 keystore.properties
+debug.keystore
 /release
 *.jks
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     signingConfigs {
         getByName("debug") {
-            storeFile = file("${rootDir}/debug.keystore")
+            storeFile = file("$rootDir/debug.keystore")
             storePassword = "android"
             keyAlias = "androiddebugkey"
             keyPassword = "android"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,13 @@ android {
     namespace = "com.unifest.android"
 
     signingConfigs {
+        getByName("debug") {
+            storeFile = file("${rootDir}/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+
         create("release") {
             val propertiesFile = rootProject.file("keystore.properties")
             val properties = Properties()

--- a/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
@@ -1,7 +1,9 @@
 package com.unifest.android.core.common.extension
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -29,4 +31,9 @@ fun Activity.navigateToAppSetting() {
         Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
         Uri.fromParts("package", packageName, null),
     ).also(::startActivity)
+}
+
+fun Activity.checkLocationPermission(): Boolean {
+    return checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+        checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
 }

--- a/core/data/impl/src/main/kotlin/com/unifest/android/core/data/impl/repository/DefaultWaitingRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/unifest/android/core/data/impl/repository/DefaultWaitingRepository.kt
@@ -18,18 +18,13 @@ class DefaultWaitingRepository @Inject constructor(
     private val firebaseMessaging: FirebaseMessaging,
 ) : WaitingRepository {
     override suspend fun getMyWaitingList() = runSuspendCatching {
-        service.getMyWaitingList(
-            deviceId = getDeviceId(context),
-        ).data?.map { it.toModel() } ?: emptyList()
+        val deviceId = getDeviceId(context)
+        service.getMyWaitingList(deviceId = deviceId).data?.map { it.toModel() } ?: emptyList()
     }
 
     override suspend fun cancelBoothWaiting(waitingId: Long): Result<Unit> = runSuspendCatching {
-        service.cancelBoothWaiting(
-            WaitingRequest(
-                waitingId = waitingId,
-                deviceId = getDeviceId(context),
-            ),
-        ).data.toModel()
+        val deviceId = getDeviceId(context)
+        service.cancelBoothWaiting(WaitingRequest(waitingId = waitingId, deviceId = deviceId)).data.toModel()
     }
 
     override suspend fun registerFCMTopic(waitingId: String) {

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
@@ -14,4 +14,22 @@ data class MyWaitingModel(
     val status: String = "",
     val waitingOrder: Long = 0L,
     val boothName: String = "",
-)
+) {
+    val waitingStatus: WaitingStatus
+        get() = WaitingStatus.fromString(status)
+}
+
+@Stable
+enum class WaitingStatus(val value: String) {
+    WAITING("WAITING"),    // 웨이팅 중
+    CALLED("CALLED"),      // 호출됨
+    COMPLETED("COMPLETED"), // 완료됨
+    NOSHOW("NOSHOW"),      // 노쇼
+    UNKNOWN("UNKNOWN");    // 알 수 없는 상태
+
+    companion object {
+        fun fromString(value: String): WaitingStatus {
+            return entries.find { it.value == value } ?: UNKNOWN
+        }
+    }
+}

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
@@ -21,7 +21,7 @@ data class MyWaitingModel(
 
 @Stable
 enum class WaitingStatus(val value: String) {
-    WAITING("WAITING"),    // 웨이팅 중
+    RESERVED("RESERVED"),    // 예약됨
     CALLED("CALLED"),      // 호출됨
     COMPLETED("COMPLETED"), // 완료됨
     NOSHOW("NOSHOW"),      // 노쇼

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/MyWaitingModel.kt
@@ -21,11 +21,21 @@ data class MyWaitingModel(
 
 @Stable
 enum class WaitingStatus(val value: String) {
-    RESERVED("RESERVED"),    // 예약됨
-    CALLED("CALLED"),      // 호출됨
-    COMPLETED("COMPLETED"), // 완료됨
-    NOSHOW("NOSHOW"),      // 노쇼
-    UNKNOWN("UNKNOWN");    // 알 수 없는 상태
+    // 예약됨
+    RESERVED("RESERVED"),
+
+    // 호출됨
+    CALLED("CALLED"),
+
+    // 완료됨
+    COMPLETED("COMPLETED"),
+
+    // 노쇼
+    NOSHOW("NOSHOW"),
+
+    // 알 수 없는 상태
+    UNKNOWN("UNKNOWN"),
+    ;
 
     companion object {
         fun fromString(value: String): WaitingStatus {

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
@@ -185,7 +185,7 @@ internal fun BoothDescription(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = stringResource(id = R.string.booth_check_locaiton),
+                text = stringResource(id = R.string.booth_check_location),
                 style = Title5,
             )
         }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -36,7 +36,8 @@ data class BoothUiState(
     val privacyConsentChecked: Boolean = false,
     val isScheduleExpanded: Boolean = false,
     val myWaitingList: ImmutableList<MyWaitingModel> = persistentListOf(),
-    val isPermissionDialogVisible: Boolean = false,
+    val isLocationPermissionDialogVisible: Boolean = false,
+    val isNotificationPermissionDialogVisible: Boolean = false,
     val outerPolygon: ImmutableList<LatLng> = persistentListOf(
         LatLng(50.0, 150.0),
         LatLng(50.0, 100.0),

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -36,6 +36,7 @@ data class BoothUiState(
     val privacyConsentChecked: Boolean = false,
     val isScheduleExpanded: Boolean = false,
     val myWaitingList: ImmutableList<MyWaitingModel> = persistentListOf(),
+    val isPermissionDialogVisible: Boolean = false,
     val outerPolygon: ImmutableList<LatLng> = persistentListOf(
         LatLng(50.0, 150.0),
         LatLng(50.0, 100.0),

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -11,6 +11,7 @@ import com.unifest.android.core.data.api.repository.BoothRepository
 import com.unifest.android.core.data.api.repository.LikedBoothRepository
 import com.unifest.android.core.data.api.repository.WaitingRepository
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.WaitingStatus
 import com.unifest.android.core.navigation.Route
 import com.unifest.android.feature.booth.R
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -84,7 +85,7 @@ class BoothViewModel @Inject constructor(
                     val currentBoothId = _uiState.value.boothDetailInfo.id
                     val matchingBooth = _uiState.value.myWaitingList.find { it.boothId == currentBoothId }
                     when {
-                        matchingBooth?.status == "NOSHOW" -> setNoShowDialogVisible(true)
+                        matchingBooth?.waitingStatus == WaitingStatus.NOSHOW -> setNoShowDialogVisible(true)
                         matchingBooth != null -> _uiEvent.send(
                             BoothUiEvent.ShowSnackBar(UiText.StringResource(R.string.booth_waiting_already_exists)),
                         )

--- a/feature/booth/src/main/res/values/strings.xml
+++ b/feature/booth/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="booth_check_locaiton">위치 확인하기</string>
+    <string name="booth_check_location">위치 확인하기</string>
     <string name="booth_menu">메뉴</string>
     <string name="booth_waiting_button">웨이팅 하기</string>
     <string name="booth_waiting_button_invalid">웨이팅 기능을 지원하지 않는 부스입니다</string>

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
@@ -20,4 +20,5 @@ data class FestivalUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val isFestivalOnboardingCompleted: Boolean = false,
+    val isNotificationPermissionDialogVisible: Boolean = false,
 )

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -80,6 +80,7 @@ import com.skydoves.compose.effects.RememberedEffect
 import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.PermissionDialogButtonType
 import com.unifest.android.core.common.UiText
+import com.unifest.android.core.common.extension.checkLocationPermission
 import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.designsystem.MarkerCategory
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
@@ -138,7 +139,7 @@ internal fun MapRoute(
     val dialogQueue = mapViewModel.permissionDialogQueue
 
     var isLocationPermissionGranted by remember {
-        mutableStateOf(checkLocationPermission(activity))
+        mutableStateOf(activity.checkLocationPermission())
     }
 
     var isNotificationPermissionGranted by remember {
@@ -157,7 +158,7 @@ internal fun MapRoute(
             permissionsToRequest.forEach { permission ->
                 when (permission) {
                     Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION -> {
-                        isLocationPermissionGranted = checkLocationPermission(activity)
+                        isLocationPermissionGranted = activity.checkLocationPermission()
                     }
 
                     Manifest.permission.POST_NOTIFICATIONS -> {
@@ -178,7 +179,7 @@ internal fun MapRoute(
         contract = ActivityResultContracts.StartActivityForResult(),
         onResult = {
             // 설정에서 돌아왔을 때 권한 상태를 다시 확인
-            isLocationPermissionGranted = checkLocationPermission(activity)
+            isLocationPermissionGranted = activity.checkLocationPermission()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 isNotificationPermissionGranted =
                     activity.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
@@ -299,11 +300,6 @@ internal fun MapRoute(
         onFestivalUiAction = festivalViewModel::onFestivalUiAction,
         isClusteringEnabled = isClusteringEnabled,
     )
-}
-
-private fun checkLocationPermission(activity: Activity): Boolean {
-    return activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
-        activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
 }
 
 @ExperimentalNaverMapApi

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -1,7 +1,6 @@
 package com.unifest.android.feature.map
 
 import android.Manifest
-import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -39,7 +39,7 @@ class StampViewModel @Inject constructor(
 
     fun onAction(action: StampUiAction) {
         when (action) {
-            is StampUiAction.OnReceiveStampClick -> requestLocationPermission()
+            is StampUiAction.OnReceiveStampClick -> requestCameraPermission()
             is StampUiAction.OnRefreshClick -> refreshCollectedStamps()
             is StampUiAction.OnFindStampBoothClick -> setStampBoothDialogVisible(true)
             is StampUiAction.OnPermissionDialogButtonClick -> handlePermissionDialogButtonClick(action.buttonType)
@@ -127,7 +127,7 @@ class StampViewModel @Inject constructor(
         getCollectedStamps(festivalId = _uiState.value.selectedFestival.festivalId, isRefresh = true)
     }
 
-    private fun requestLocationPermission() {
+    private fun requestCameraPermission() {
         viewModelScope.launch {
             _uiEvent.send(StampUiEvent.RequestCameraPermission)
         }

--- a/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/component/WaitingInfoItem.kt
+++ b/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/component/WaitingInfoItem.kt
@@ -213,7 +213,7 @@ private fun WaitingInfoItemPreview() {
                 deviceId = "1234567890",
                 createdAt = "2024-05-23",
                 updatedAt = "2024-05-23",
-                status = "WAITING",
+                status = "RESERVED",
                 waitingOrder = 1L,
                 boothName = "부스 이름",
             ),

--- a/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/component/WaitingInfoItem.kt
+++ b/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/component/WaitingInfoItem.kt
@@ -36,6 +36,7 @@ import com.unifest.android.core.designsystem.theme.WaitingNumber
 import com.unifest.android.core.designsystem.theme.WaitingNumber2
 import com.unifest.android.core.designsystem.theme.WaitingNumber5
 import com.unifest.android.core.model.MyWaitingModel
+import com.unifest.android.core.model.WaitingStatus
 import com.unifest.android.feature.waiting.R
 import com.unifest.android.feature.waiting.viewmodel.WaitingUiAction
 import com.unifest.android.core.designsystem.R as designR
@@ -50,7 +51,7 @@ internal fun WaitingInfoItem(
             .fillMaxWidth()
             .shadow(elevation = 8.dp, shape = RoundedCornerShape(8.dp))
             .background(
-                color = if (myWaitingModel.status != "NOSHOW") {
+                color = if (myWaitingModel.waitingStatus != WaitingStatus.NOSHOW) {
                     MaterialTheme.colorScheme.surfaceBright
                 } else {
                     MaterialTheme.colorScheme.surfaceContainerHigh
@@ -61,7 +62,7 @@ internal fun WaitingInfoItem(
         Column(
             modifier = Modifier
                 .then(
-                    if (myWaitingModel.status != "NOSHOW") {
+                    if (myWaitingModel.waitingStatus != WaitingStatus.NOSHOW) {
                         Modifier.background(MaterialTheme.colorScheme.surfaceBright)
                     } else {
                         Modifier
@@ -103,21 +104,17 @@ internal fun WaitingInfoItem(
                     verticalAlignment = Alignment.Bottom,
                 ) {
                     Text(
-                        text = when (myWaitingModel.status) {
-                            "NOSHOW" -> stringResource(id = R.string.waiting_no_show)
-                            "CALLED" -> stringResource(id = R.string.waiting_my_turn)
+                        text = when (myWaitingModel.waitingStatus) {
+                            WaitingStatus.NOSHOW -> stringResource(id = R.string.waiting_no_show)
+                            WaitingStatus.CALLED -> stringResource(id = R.string.waiting_my_turn)
                             else -> myWaitingModel.waitingOrder.toString()
                         },
-                        style = if (myWaitingModel.status == "CALLED") WaitingNumber5 else WaitingNumber,
-                        color = if (myWaitingModel.status == "NOSHOW") {
-                            LightPrimary700
-                        } else {
-                            MaterialTheme.colorScheme.primary
-                        },
+                        style = if (myWaitingModel.waitingStatus == WaitingStatus.CALLED) WaitingNumber5 else WaitingNumber,
+                        color = if (myWaitingModel.waitingStatus == WaitingStatus.NOSHOW) LightPrimary700 else MaterialTheme.colorScheme.primary,
                         modifier = Modifier.alignByBaseline(),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    if (myWaitingModel.status != "CALLED" && myWaitingModel.status != "NOSHOW") {
+                    if (myWaitingModel.waitingStatus != WaitingStatus.CALLED && myWaitingModel.waitingStatus != WaitingStatus.NOSHOW) {
                         Text(
                             text = stringResource(id = R.string.waiting_nth),
                             fontSize = 18.sp,
@@ -167,7 +164,7 @@ internal fun WaitingInfoItem(
             ) {
                 UnifestButton(
                     onClick = {
-                        if (myWaitingModel.status == "NOSHOW") {
+                        if (myWaitingModel.waitingStatus == WaitingStatus.NOSHOW) {
                             onWaitingUiAction(WaitingUiAction.OnCancelNoShowWaitingClick(myWaitingModel.waitingId))
                         } else {
                             onWaitingUiAction(WaitingUiAction.OnCancelWaitingClick(myWaitingModel.waitingId))
@@ -177,7 +174,7 @@ internal fun WaitingInfoItem(
                     modifier = Modifier.weight(1f),
                 ) {
                     Text(
-                        text = if (myWaitingModel.status == "NOSHOW") {
+                        text = if (myWaitingModel.waitingStatus == WaitingStatus.NOSHOW) {
                             stringResource(id = R.string.waiting_no_show_description)
                         } else {
                             stringResource(id = R.string.waiting_cancel_waiting)
@@ -216,7 +213,7 @@ private fun WaitingInfoItemPreview() {
                 deviceId = "1234567890",
                 createdAt = "2024-05-23",
                 updatedAt = "2024-05-23",
-                status = "waiting",
+                status = "WAITING",
                 waitingOrder = 1L,
                 boothName = "부스 이름",
             ),

--- a/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/viewmodel/WaitingViewModel.kt
+++ b/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/viewmodel/WaitingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.data.api.repository.WaitingRepository
 import com.unifest.android.core.common.ErrorHandlerActions
 import com.unifest.android.core.common.handleException
+import com.unifest.android.core.model.WaitingStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
@@ -51,7 +52,11 @@ class WaitingViewModel @Inject constructor(
             waitingRepository.getMyWaitingList()
                 .onSuccess { waitingLists ->
                     _uiState.update {
-                        it.copy(myWaitingList = waitingLists.toImmutableList())
+                        it.copy(
+                            myWaitingList = waitingLists.filter {
+                                it.waitingStatus != WaitingStatus.COMPLETED
+                            }.toImmutableList(),
+                        )
                     }
                 }
                 .onFailure { exception ->

--- a/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/viewmodel/WaitingViewModel.kt
+++ b/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/viewmodel/WaitingViewModel.kt
@@ -27,10 +27,6 @@ class WaitingViewModel @Inject constructor(
     private val _uiEvent = Channel<WaitingUiEvent>()
     val uiEvent: Flow<WaitingUiEvent> = _uiEvent.receiveAsFlow()
 
-    init {
-        getMyWaitingList(isRefresh = false)
-    }
-
     fun onWaitingUiAction(action: WaitingUiAction) {
         when (action) {
             is WaitingUiAction.OnCancelWaitingClick -> setWaitingCancelDialogWaitingId(action.waitingId)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "27"
-versionName = "1.3.0"
+versionCode = "28"
+versionName = "1.3.1"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidx-activity-compose = "1.10.1"
 androidx-compose = "1.7.4"
 androidx-compose-material3 = "1.3.2"
 androidx-hilt-navigation-compose = "1.2.0"
-androidx-test-core = "1.6.2"
+androidx-test-core = "1.6.1"
 
 desugar-jdk-libs = "2.1.5"
 hilt = "2.55"


### PR DESCRIPTION
feat)
- 디버그 서명키 추가(다른 노트북 환경에서 같은 devideId(SSAID)를 발급받기 위함)

fix)
- 웨이팅 화면 COMPLETED 상태의 웨이팅 아이템 filter 처리 
- CD workflow 수정 (debug apk를 firebabase app distribution에 배포)
- 초기 진입시 waiting API 중복 호출 문제 해결

refactor)
- 하드코딩된 웨이팅 관련 status enum 으로 관리 방식 변경
- 권한 체크 관련 함수 확장함수로 변경

chore)
- resource 파일 내 오타 수정 
- 함수 이름 올바르게 변경 

To be continue...)
부스 상세 화면)
- 부스 위치 확인 하기 버튼 클릭시 위치 권한 체크 플로우 추가
- 부스 웨이팅하기 버튼 클릭시 알림 권한 체크 플로우 추가

축제 바텀시트 화면)
- 관심 축제 추가 버튼 클릭시 알림 권한 체크 플로우 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 위치 권한 및 알림 권한 다이얼로그 표시 여부를 관리하는 UI 상태가 추가되었습니다.
    - 위치 권한 확인을 위한 확장 함수가 도입되었습니다.
    - 대기 상태를 enum 타입으로 제공하여 더 명확하게 상태를 구분합니다.

- **버그 수정**
    - 부스 위치 확인 버튼의 오타가 수정되었습니다.

- **기능 개선**
    - 대기 목록에서 완료된 항목이 제외되어 표시됩니다.
    - 대기 상태 비교 및 처리 로직이 문자열에서 enum 기반으로 개선되었습니다.
    - 스탬프 수령 시 위치 권한 대신 카메라 권한을 요청하도록 변경되었습니다.

- **릴리즈**
    - 앱 버전이 1.3.1(28)로 업데이트되었습니다.
    - 디버그 APK 배포로 워크플로우가 변경되었습니다.
    - 디버그 서명키 설정 및 관련 CI/CD 워크플로우가 추가되어 안정적인 디버그 빌드 배포가 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->