### PR TITLE
[feat] 스탬프 화면 드롭다운 스크롤바 추가, 최근 관심 축제와 스탬프 지원 축제 목록간의 동기화 문제 해결 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 - [Calendar](https://github.com/kizitonwose/Calendar)
 - [Zxing](https://github.com/journeyapps/zxing-android-embedded)
 - [compose-effects](https://github.com/skydoves/compose-effects)
+- [compose-unstyled](https://github.com/composablehorizons/compose-unstyled/)
 
 #### Test & Code analysis
 
@@ -118,7 +119,7 @@ Google Recommend Architecture based on [Now in Android](https://github.com/andro
 │   ├── home
 │   ├── intro
 │   ├── liked-booth
-│   ├── main 
+│   ├── main
 │   ├── map
 │   ├── menu
 │   ├── navigator

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Theme.kt
@@ -69,6 +69,8 @@ private val LightColorScheme = lightColorScheme(
     surfaceContainer = Color.White,
     // 높은 대비의 표면 컨테이너, 중요 정보나 액션을 담는 컨테이너
     surfaceContainerHigh = LightPrimary50,
+    // 낮은 대비의 표면 컨테이너, 부차적인 정보나 배경 요소에 사용
+    surfaceContainerLow = DarkGrey700,
     // 역전된 표면 색상, 어두운 배경 위 밝은 요소를 위해 사용
     inverseSurface = LightGrey100,
     // inverseSurface 위의 텍스트나 밝은 강조에 사용
@@ -105,6 +107,7 @@ private val DarkColorScheme = darkColorScheme(
     surfaceBright = DarkGrey200,
     surfaceContainer = DarkGrey100,
     surfaceContainerHigh = DarkGrey300,
+    surfaceContainerLow = DarkGrey400,
     inverseSurface = DarkGrey300,
     inverseOnSurface = LightGrey100,
 )

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -58,13 +58,13 @@ class MapViewModel @Inject constructor(
     }
 
     init {
-        requestLocationPermission()
+        requestPermissions()
         getRecentLikedFestivalStream()
         getAllFestivals()
         checkMapOnboardingCompletion()
     }
 
-    private fun requestLocationPermission() {
+    private fun requestPermissions() {
         viewModelScope.launch {
             _uiEvent.send(MapUiEvent.RequestPermissions)
         }

--- a/feature/stamp/build.gradle.kts
+++ b/feature/stamp/build.gradle.kts
@@ -18,5 +18,6 @@ dependencies {
         libs.coil.compose,
         libs.zxing.android.embedded,
         libs.timber,
+        libs.compose.unstyled,
     )
 }

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
@@ -313,7 +313,6 @@ internal fun StampContent(
                         ) { index ->
                             StampItem(
                                 collectedStampCount = uiState.collectedStampCount,
-                                stampEnabledFestivalList = uiState.stampEnabledFestivalList,
                                 selectedFestival = uiState.selectedFestival,
                                 index = index,
                             )

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -22,13 +21,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -41,11 +38,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.SpanStyle
@@ -62,7 +57,6 @@ import com.unifest.android.core.common.extension.clickableSingle
 import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.designsystem.component.LoadingWheel
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
-import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.component.ServerErrorDialog
 import com.unifest.android.core.designsystem.theme.BoothTitle2
 import com.unifest.android.core.designsystem.theme.Content2
@@ -81,6 +75,7 @@ import com.unifest.android.core.ui.component.PermissionDialog
 import com.unifest.android.feature.stamp.component.SchoolsDropDownMenu
 import com.unifest.android.feature.stamp.component.StampBoothBottomSheet
 import com.unifest.android.feature.stamp.component.StampButton
+import com.unifest.android.feature.stamp.component.StampItem
 import com.unifest.android.feature.stamp.preview.StampPreviewParameterProvider
 import com.unifest.android.feature.stamp.viewmodel.stamp.ErrorType
 import com.unifest.android.feature.stamp.viewmodel.stamp.StampUiAction
@@ -316,34 +311,12 @@ internal fun StampContent(
                             count = uiState.stampBoothList.size,
                             key = { index -> uiState.stampBoothList[index].id },
                         ) { index ->
-                            Box {
-                                val isCollected = index < uiState.collectedStampCount
-                                val imgUrl = if (isCollected) uiState.stampEnabledFestivalList[0].usedImgUrl
-                                else uiState.stampEnabledFestivalList[0].defaultImgUrl
-
-                                val fallbackResourceId = if (isCollected) R.drawable.ic_checked_stamp
-                                else R.drawable.ic_unchecked_stamp
-
-                                val contentDescription = if (isCollected) "Stamp Used Image"
-                                else "Stamp Default Image"
-
-                                if (imgUrl.isNotEmpty()) {
-                                    NetworkImage(
-                                        imgUrl = imgUrl,
-                                        contentDescription = contentDescription,
-                                        modifier = Modifier
-                                            .size(62.dp)
-                                            .clip(CircleShape),
-                                        placeholder = painterResource(id = fallbackResourceId),
-                                    )
-                                } else {
-                                    Image(
-                                        painter = painterResource(id = fallbackResourceId),
-                                        contentDescription = contentDescription,
-                                        modifier = Modifier.size(62.dp),
-                                    )
-                                }
-                            }
+                            StampItem(
+                                collectedStampCount = uiState.collectedStampCount,
+                                stampEnabledFestivalList = uiState.stampEnabledFestivalList,
+                                selectedFestival = uiState.selectedFestival,
+                                index = index,
+                            )
                         }
                     }
                     Spacer(modifier = Modifier.height(28.dp))

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/SchoolsDropDownMenu.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/SchoolsDropDownMenu.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +32,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import com.composables.core.ScrollArea
+import com.composables.core.Thumb
+import com.composables.core.VerticalScrollbar
+import com.composables.core.rememberScrollAreaState
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.BoothTitle2
 import com.unifest.android.core.designsystem.theme.StampSchools
@@ -48,6 +54,9 @@ internal fun SchoolsDropDownMenu(
     onAction: (StampUiAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val lazyListState = rememberLazyListState()
+    val state = rememberScrollAreaState(lazyListState)
+
     val offsetInPx = with(LocalDensity.current) { 64.dp.toPx() }
 
     Column(modifier = modifier) {
@@ -100,32 +109,55 @@ internal fun SchoolsDropDownMenu(
                     shape = RoundedCornerShape(8.dp),
                     shadowElevation = 4.dp,
                 ) {
-                    LazyColumn(
+                    ScrollArea(
+                        state = state,
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .height(if (festivals.isEmpty()) 0.dp else (festivals.size * 48).dp)
-                            .heightIn(max = 240.dp),
+                            .background(color = MaterialTheme.colorScheme.inverseSurface)
+                            .padding(end = 9.dp),
                     ) {
-                        items(
-                            items = festivals,
-                            key = { it.festivalId },
-                        ) { school ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable(
-                                        onClick = { onAction(StampUiAction.OnFestivalSelect(school)) },
+                        LazyColumn(
+                            state = lazyListState,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(if (festivals.isEmpty()) 0.dp else (festivals.size * 48).dp)
+                                .heightIn(max = 240.dp),
+                            contentPadding = PaddingValues(vertical = 5.dp),
+                        ) {
+                            items(
+                                items = festivals,
+                                key = { it.festivalId },
+                            ) { school ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable(
+                                            onClick = { onAction(StampUiAction.OnFestivalSelect(school)) },
+                                        )
+                                        .background(color = MaterialTheme.colorScheme.inverseSurface)
+                                        .padding(horizontal = 25.dp, vertical = 12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = school.name,
+                                        style = StampSchools,
+                                        color = MaterialTheme.colorScheme.inverseOnSurface,
                                     )
-                                    .background(color = MaterialTheme.colorScheme.inverseSurface)
-                                    .padding(horizontal = 25.dp, vertical = 15.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(
-                                    text = school.name,
-                                    style = StampSchools,
-                                    color = MaterialTheme.colorScheme.inverseOnSurface,
-                                )
+                                }
                             }
+                        }
+                        VerticalScrollbar(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .height(if (festivals.isEmpty()) 0.dp else (festivals.size * 48).dp)
+                                .heightIn(max = 240.dp)
+                                .width(7.dp),
+                        ) {
+                            Thumb(
+                                modifier = Modifier
+                                    .padding(vertical = 9.dp)
+                                    .clip(RoundedCornerShape(7.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
+                            )
                         }
                     }
                 }

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.component.NetworkImage
@@ -30,8 +31,8 @@ internal fun StampItem(
         val fallbackResourceId = if (isCollected) R.drawable.ic_checked_stamp
         else R.drawable.ic_unchecked_stamp
 
-        val contentDescription = if (isCollected) "Stamp Used Image"
-        else "Stamp Default Image"
+        val contentDescription = if (isCollected) stringResource(R.string.stamp_used_image)
+        else stringResource(R.string.stamp_default_image)
 
         if (imgUrl.isNotEmpty()) {
             NetworkImage(

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
@@ -1,0 +1,81 @@
+package com.unifest.android.feature.stamp.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.component.NetworkImage
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.StampFestivalModel
+import com.unifest.android.feature.stamp.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun StampItem(
+    collectedStampCount: Int,
+    stampEnabledFestivalList: ImmutableList<StampFestivalModel>,
+    selectedFestival: StampFestivalModel,
+    index: Int,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+    ) {
+        // TODO index 0 고정이 맞나?
+        val isCollected = index < collectedStampCount
+        val imgUrl = if (isCollected) stampEnabledFestivalList[0].usedImgUrl
+        else stampEnabledFestivalList[0].defaultImgUrl
+
+        val fallbackResourceId = if (isCollected) R.drawable.ic_checked_stamp
+        else R.drawable.ic_unchecked_stamp
+
+        val contentDescription = if (isCollected) "Stamp Used Image"
+        else "Stamp Default Image"
+
+        if (imgUrl.isNotEmpty()) {
+            NetworkImage(
+                imgUrl = imgUrl,
+                contentDescription = contentDescription,
+                modifier = Modifier
+                    .size(62.dp)
+                    .clip(CircleShape),
+                placeholder = painterResource(id = fallbackResourceId),
+            )
+        } else {
+            Image(
+                painter = painterResource(id = fallbackResourceId),
+                contentDescription = contentDescription,
+                modifier = Modifier.size(62.dp),
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun StampItemPreview() {
+    val mockStampFestivalModel = StampFestivalModel(
+        festivalId = 1,
+        name = "축제",
+        defaultImgUrl = "",
+        usedImgUrl = "",
+    )
+
+    val mockStampEnabledFestivalList = persistentListOf(mockStampFestivalModel)
+
+    UnifestTheme {
+        StampItem(
+            collectedStampCount = 10,
+            stampEnabledFestivalList = mockStampEnabledFestivalList,
+            selectedFestival = mockStampFestivalModel,
+            index = 1,
+        )
+    }
+}

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
@@ -14,13 +14,10 @@ import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.StampFestivalModel
 import com.unifest.android.feature.stamp.R
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun StampItem(
     collectedStampCount: Int,
-    stampEnabledFestivalList: ImmutableList<StampFestivalModel>,
     selectedFestival: StampFestivalModel,
     index: Int,
     modifier: Modifier = Modifier,
@@ -28,11 +25,8 @@ internal fun StampItem(
     Box(
         modifier = modifier,
     ) {
-        // TODO index 0 고정이 맞나?
         val isCollected = index < collectedStampCount
-        val imgUrl = if (isCollected) stampEnabledFestivalList[0].usedImgUrl
-        else stampEnabledFestivalList[0].defaultImgUrl
-
+        val imgUrl = if (isCollected) selectedFestival.usedImgUrl else selectedFestival.defaultImgUrl
         val fallbackResourceId = if (isCollected) R.drawable.ic_checked_stamp
         else R.drawable.ic_unchecked_stamp
 
@@ -61,20 +55,15 @@ internal fun StampItem(
 @ComponentPreview
 @Composable
 private fun StampItemPreview() {
-    val mockStampFestivalModel = StampFestivalModel(
-        festivalId = 1,
-        name = "축제",
-        defaultImgUrl = "",
-        usedImgUrl = "",
-    )
-
-    val mockStampEnabledFestivalList = persistentListOf(mockStampFestivalModel)
-
     UnifestTheme {
         StampItem(
             collectedStampCount = 10,
-            stampEnabledFestivalList = mockStampEnabledFestivalList,
-            selectedFestival = mockStampFestivalModel,
+            selectedFestival = StampFestivalModel(
+                festivalId = 1,
+                name = "축제",
+                defaultImgUrl = "",
+                usedImgUrl = "",
+            ),
             index = 1,
         )
     }

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -103,9 +103,13 @@ class StampViewModel @Inject constructor(
     private fun getRecentLikedFestivalStream() {
         viewModelScope.launch {
             likedFestivalRepository.getRecentLikedFestivalStream().collect { recentLikedFestival ->
-                _uiState.update {
-                    it.copy(
-                        selectedFestival = StampFestivalModel(
+                _uiState.update { currentState ->
+                    val matchingFestival = currentState.stampEnabledFestivalList.find {
+                        it.festivalId == recentLikedFestival.festivalId
+                    }
+
+                    currentState.copy(
+                        selectedFestival = matchingFestival ?: StampFestivalModel(
                             festivalId = recentLikedFestival.festivalId,
                             name = recentLikedFestival.schoolName,
                             defaultImgUrl = "",

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -114,17 +114,7 @@ class StampViewModel @Inject constructor(
                 likedFestivalRepository.getRecentLikedFestivalStream(),
                 stampEnabledFestivalsFlow,
             ) { recentLikedFestival, stampEnabledFestivals ->
-                val matchingFestival = stampEnabledFestivals.find {
-                    it.festivalId == recentLikedFestival.festivalId
-                }
-
-                if (matchingFestival != null) {
-                    Timber.d("매칭된 축제 찾음 - ID: ${matchingFestival.festivalId}, 이름: ${matchingFestival.name}")
-                    Timber.d("이미지 URL - 기본: ${matchingFestival.defaultImgUrl}, 사용됨: ${matchingFestival.usedImgUrl}")
-                } else {
-                    Timber.d("최근 좋아한 축제(ID: ${recentLikedFestival.festivalId})와 일치하는 스탬프 활성화 축제 없음")
-                }
-
+                val matchingFestival = stampEnabledFestivals.find { it.festivalId == recentLikedFestival.festivalId }
                 Pair(recentLikedFestival, matchingFestival)
             }.collect { (recentLikedFestival, matchingFestival) ->
                 _uiState.update { currentState ->

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel

--- a/feature/stamp/src/main/res/values/strings.xml
+++ b/feature/stamp/src/main/res/values/strings.xml
@@ -12,5 +12,7 @@
     <string name="stamp_register_completed">스탬프가 성공적으로 등록 되었습니다.</string>
     <string name="stamp_register_failed">올바르지 않은 QR코드입니다. 운영자에 문의바랍니다.</string>
     <string name="stamp_not_support_school">스탬프를 지원하지 않는 학교입니다</string>
+    <string name="stamp_used_image">Stamp Used Image</string>
+    <string name="stamp_default_image">"Stamp Default Image"</string>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ balloon = "1.6.12"
 calendar-compose = "2.6.2"
 flexible-bottomsheet = "0.1.5"
 compose-effects = "0.1.1"
+compose-unstyled = "1.25.0"
 
 naver-map-compose = "1.7.1"
 naver-map-location = "21.0.1"
@@ -145,6 +146,7 @@ naver-map-location = { group = "io.github.fornewid", name = "naver-map-location"
 tedclustering-naver = { group = "io.github.ParkSangGwon", name = "tedclustering-naver", version.ref = "tedclustering-naver" }
 zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing" }
 compose-effects = { group = "com.github.skydoves", name = "compose-effects", version.ref = "compose-effects" }
+compose-unstyled = { group = "com.composables", name = "core", version.ref = "compose-unstyled" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "28"
-versionName = "1.3.1"
+versionCode = "29"
+versionName = "1.3.2"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"


### PR DESCRIPTION
feat)
- compose-unstyled 라이브러리 의존성 추가 (각종 편리한 컴포즈 컴포넌트 지원)
- 스탬프 화면 드롭다운 스크롤바 추가(compose unstyled 에서 지원하는 scrollbar 사용)

refactor)
- StampItem 컴포넌트 분리 

fix)
- 최근 선택된 관심 축제를 스탬프 화면 드롭다운에 default 축제로 매핑하는 과정에서, 
스탬프 이미지 동기화 관련 타이밍 문제가 발생할 수 있어 이를 해결 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 축제 스탬프 화면에 개별 스탬프 아이템을 표시하는 새로운 컴포넌트가 추가되었습니다.
    - 축제 선택 드롭다운 메뉴에 스크롤바가 추가되어 많은 항목을 쉽게 탐색할 수 있습니다.

- **Refactor**
    - 스탬프 화면의 코드 구조가 개선되어 스탬프 아이템 렌더링이 별도의 컴포넌트로 분리되었습니다.
    - 축제 선택 로직이 개선되어 최근 좋아요한 축제와 활성화된 축제 목록을 조합하여 더 정확하게 선택됩니다.

- **Style**
    - 테마에 새로운 색상 속성이 추가되어 UI 배경 표현이 다양해졌습니다.

- **Chores**
    - 새로운 라이브러리(Compose Unstyled)가 프로젝트에 추가되었습니다.
    - 앱 버전이 1.3.2로 업데이트되었습니다.

- **Documentation**
    - README에 새로운 라이브러리 링크가 추가되고, 일부 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->