### PR TITLE
[refactor] 권한 허용 관련 로직 개선 및 스탬프 API 변경사항 반영 

### DIFF
--- a/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
@@ -26,14 +26,15 @@ inline fun <reified T : Activity> Activity.startActivityWithAnimation(
     if (withFinish) finish()
 }
 
-fun Activity.navigateToAppSetting() {
-    Intent(
-        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-        Uri.fromParts("package", packageName, null),
-    ).also(::startActivity)
-}
-
 fun Activity.checkLocationPermission(): Boolean {
     return checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
         checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+}
+
+fun Activity.checkNotificationPermission(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+    } else {
+        true
+    }
 }

--- a/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/extension/Activity.kt
@@ -4,9 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
 
 inline fun <reified T : Activity> Activity.startActivityWithAnimation(
     withFinish: Boolean,

--- a/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/StampMapper.kt
+++ b/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/StampMapper.kt
@@ -37,7 +37,7 @@ internal fun StampRecord.toModel(): StampRecordModel {
 internal fun StampFestival.toModel(): StampFestivalModel {
     return StampFestivalModel(
         festivalId = festivalId,
-        name = name,
+        schoolName = schoolName,
         defaultImgUrl = defaultImgUrl,
         usedImgUrl = usedImgUrl,
     )

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/StampFestivalModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/StampFestivalModel.kt
@@ -2,7 +2,7 @@ package com.unifest.android.core.model
 
 data class StampFestivalModel(
     val festivalId: Long,
-    val name: String,
+    val schoolName: String,
     val defaultImgUrl: String,
     val usedImgUrl: String,
 )

--- a/core/network/src/main/kotlin/com/unifest/android/core/network/response/stamp/StampFestivalsResponse.kt
+++ b/core/network/src/main/kotlin/com/unifest/android/core/network/response/stamp/StampFestivalsResponse.kt
@@ -17,8 +17,8 @@ data class StampFestivalsResponse(
 data class StampFestival(
     @SerialName("festivalId")
     val festivalId: Long,
-    @SerialName("name")
-    val name: String,
+    @SerialName("schoolName")
+    val schoolName: String,
     @SerialName("defaultImgUrl")
     val defaultImgUrl: String,
     @SerialName("usedImgUrl")

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -2,7 +2,6 @@ package com.unifest.android.feature.booth
 
 import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothDetailScreen.kt
@@ -224,12 +224,12 @@ internal fun BoothDetailRoute(
     if (uiState.isLocationPermissionDialogVisible) {
         PermissionDialog(
             permissionTextProvider = LocationPermissionTextProvider(),
-            isPermanentlyDeclined = !activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION),
+            isPermanentlyDeclined = !activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION),
             onDismiss = {
                 viewModel.onAction(
                     BoothUiAction.OnPermissionDialogButtonClick(
                         buttonType = PermissionDialogButtonType.DISMISS,
-                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                        permission = Manifest.permission.ACCESS_COARSE_LOCATION,
                     ),
                 )
             },
@@ -237,7 +237,7 @@ internal fun BoothDetailRoute(
                 viewModel.onAction(
                     BoothUiAction.OnPermissionDialogButtonClick(
                         buttonType = PermissionDialogButtonType.NAVIGATE_TO_APP_SETTING,
-                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                        permission = Manifest.permission.ACCESS_COARSE_LOCATION,
                     ),
                 )
             },
@@ -245,7 +245,7 @@ internal fun BoothDetailRoute(
                 viewModel.onAction(
                     BoothUiAction.OnPermissionDialogButtonClick(
                         buttonType = PermissionDialogButtonType.CONFIRM,
-                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                        permission = Manifest.permission.ACCESS_COARSE_LOCATION,
                     ),
                 )
             },

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -60,9 +60,10 @@ internal fun BoothLocationScreen(
                 isNightModeEnabled = isSystemInDarkTheme(),
             ),
             uiSettings = MapUiSettings(
-                isZoomControlEnabled = false,
+                isZoomControlEnabled = true,
                 isScaleBarEnabled = false,
                 isLogoClickEnabled = false,
+                isLocationButtonEnabled = true,
             ),
         ) {
             PolygonOverlay(

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -21,6 +21,7 @@ import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.PolygonOverlay
 import com.naver.maps.map.compose.rememberCameraPositionState
+import com.naver.maps.map.compose.rememberFusedLocationSource
 import com.naver.maps.map.compose.rememberMarkerState
 import com.unifest.android.core.designsystem.MarkerCategory
 import com.unifest.android.core.designsystem.theme.UnifestTheme
@@ -65,6 +66,7 @@ internal fun BoothLocationScreen(
                 isLogoClickEnabled = false,
                 isLocationButtonEnabled = true,
             ),
+            locationSource = rememberFusedLocationSource(),
         ) {
             PolygonOverlay(
                 coords = uiState.outerPolygon,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
 import com.naver.maps.map.compose.MapProperties
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
@@ -58,6 +59,7 @@ internal fun BoothLocationScreen(
             cameraPositionState = cameraPositionState,
             modifier = Modifier.fillMaxSize(),
             properties = MapProperties(
+                locationTrackingMode = LocationTrackingMode.NoFollow,
                 isNightModeEnabled = isSystemInDarkTheme(),
             ),
             uiSettings = MapUiSettings(

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothLocationScreen.kt
@@ -1,13 +1,23 @@
 package com.unifest.android.feature.booth
 
+import android.Manifest
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -24,11 +34,19 @@ import com.naver.maps.map.compose.PolygonOverlay
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberFusedLocationSource
 import com.naver.maps.map.compose.rememberMarkerState
+import com.unifest.android.core.common.ObserveAsEvents
+import com.unifest.android.core.common.PermissionDialogButtonType
+import com.unifest.android.core.common.extension.checkLocationPermission
+import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.designsystem.MarkerCategory
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.ui.DevicePreview
+import com.unifest.android.core.ui.component.LocationPermissionTextProvider
+import com.unifest.android.core.ui.component.PermissionDialog
 import com.unifest.android.feature.booth.component.BoothLocationAppBar
 import com.unifest.android.feature.booth.preview.BoothDetailPreviewParameterProvider
+import com.unifest.android.feature.booth.viewmodel.BoothUiAction
+import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
 import com.unifest.android.feature.booth.viewmodel.BoothViewModel
 
@@ -38,10 +56,69 @@ internal fun BoothLocationRoute(
     viewModel: BoothViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val activity = context.findActivity()
+    var isLocationPermissionGranted by remember { mutableStateOf(activity.checkLocationPermission()) }
+
+    val settingsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+        onResult = {
+            // 설정에서 돌아왔을 때 권한 상태를 다시 확인
+            isLocationPermissionGranted = activity.checkLocationPermission()
+            viewModel.onPermissionResult(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                isGranted = isLocationPermissionGranted,
+            )
+        },
+    )
+
+    ObserveAsEvents(flow = viewModel.uiEvent) { event ->
+        when (event) {
+            is BoothUiEvent.NavigateBack -> popBackStack()
+            is BoothUiEvent.NavigateToAppSetting -> {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", activity.packageName, null)
+                }
+                settingsLauncher.launch(intent)
+            }
+            else -> {}
+        }
+    }
+
+    if (uiState.isLocationPermissionDialogVisible && !isLocationPermissionGranted) {
+        PermissionDialog(
+            permissionTextProvider = LocationPermissionTextProvider(),
+            isPermanentlyDeclined = !activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION),
+            onDismiss = {
+                viewModel.onAction(
+                    BoothUiAction.OnPermissionDialogButtonClick(
+                        buttonType = PermissionDialogButtonType.DISMISS,
+                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                    )
+                )
+            },
+            navigateToAppSetting = {
+                viewModel.onAction(
+                    BoothUiAction.OnPermissionDialogButtonClick(
+                        buttonType = PermissionDialogButtonType.NAVIGATE_TO_APP_SETTING,
+                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                    )
+                )
+            },
+            onConfirm = {
+                viewModel.onAction(
+                    BoothUiAction.OnPermissionDialogButtonClick(
+                        buttonType = PermissionDialogButtonType.CONFIRM,
+                        permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                    )
+                )
+            },
+        )
+    }
 
     BoothLocationScreen(
         uiState = uiState,
-        popBackStack = popBackStack,
+        onAction = viewModel::onAction,
     )
 }
 
@@ -49,7 +126,7 @@ internal fun BoothLocationRoute(
 @Composable
 internal fun BoothLocationScreen(
     uiState: BoothUiState,
-    popBackStack: () -> Unit,
+    onAction: (BoothUiAction) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         val cameraPositionState = rememberCameraPositionState {
@@ -75,7 +152,7 @@ internal fun BoothLocationScreen(
                 color = Color.Gray.copy(alpha = 0.3f),
                 outlineColor = Color.Gray,
                 outlineWidth = 1.dp,
-                holes = uiState.innerPolylines,
+                holes = uiState.innerPolyLines,
             )
 
             Marker(
@@ -91,7 +168,7 @@ internal fun BoothLocationScreen(
         }
 
         BoothLocationAppBar(
-            onBackClick = popBackStack,
+            onBackClick = { onAction(BoothUiAction.OnBackClick) },
             boothName = uiState.boothDetailInfo.name,
             boothLocation = uiState.boothDetailInfo.location,
             modifier = Modifier.align(Alignment.TopCenter),
@@ -108,7 +185,7 @@ private fun BoothLocationScreenPreview(
     UnifestTheme {
         BoothLocationScreen(
             uiState = boothUiState,
-            popBackStack = {},
+            onAction = {},
         )
     }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothBottomBar.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothBottomBar.kt
@@ -20,12 +20,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.unifest.android.core.common.extension.checkNotificationPermission
 import com.unifest.android.core.common.extension.clickableSingle
+import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.component.UnifestButton
 import com.unifest.android.core.designsystem.theme.BoothCaution
@@ -43,6 +46,9 @@ internal fun BoothBottomBar(
     onAction: (BoothUiAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val activity = context.findActivity()
+
     Surface(
         modifier = modifier.height(116.dp),
         shadowElevation = 32.dp,
@@ -76,7 +82,11 @@ internal fun BoothBottomBar(
                 }
                 Spacer(modifier = Modifier.width(18.dp))
                 UnifestButton(
-                    onClick = { onAction(BoothUiAction.OnWaitingButtonClick) },
+                    onClick = { if (activity.checkNotificationPermission()) {
+                        onAction(BoothUiAction.OnWaitingButtonClick)
+                    } else {
+                        onAction(BoothUiAction.OnRequestNotificationPermission)
+                    }},
                     modifier = Modifier.fillMaxWidth(),
                     contentPadding = PaddingValues(vertical = 15.dp),
                     enabled = isWaitingEnable,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothBottomBar.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothBottomBar.kt
@@ -82,11 +82,13 @@ internal fun BoothBottomBar(
                 }
                 Spacer(modifier = Modifier.width(18.dp))
                 UnifestButton(
-                    onClick = { if (activity.checkNotificationPermission()) {
-                        onAction(BoothUiAction.OnWaitingButtonClick)
-                    } else {
-                        onAction(BoothUiAction.OnRequestNotificationPermission)
-                    }},
+                    onClick = {
+                        if (activity.checkNotificationPermission()) {
+                            onAction(BoothUiAction.OnWaitingButtonClick)
+                        } else {
+                            onAction(BoothUiAction.OnRequestNotificationPermission)
+                        }
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     contentPadding = PaddingValues(vertical = 15.dp),
                     enabled = isWaitingEnable,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
@@ -27,10 +27,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.unifest.android.core.common.extension.checkLocationPermission
+import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.common.extension.toFormattedString
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
@@ -60,6 +63,8 @@ internal fun BoothDescription(
     onAction: (BoothUiAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val activity = context.findActivity()
     val configuration = LocalConfiguration.current
     val maxWidth = remember(configuration) {
         val screenWidth = configuration.screenWidthDp.dp - 40.dp
@@ -181,7 +186,13 @@ internal fun BoothDescription(
         }
         Spacer(modifier = Modifier.height(16.dp))
         UnifestOutlinedButton(
-            onClick = { onAction(BoothUiAction.OnCheckLocationClick) },
+            onClick = {
+                if (activity.checkLocationPermission()) {
+                    onAction(BoothUiAction.OnCheckLocationClick)
+                } else {
+                    onAction(BoothUiAction.OnRequestLocationPermission)
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
@@ -63,8 +63,6 @@ internal fun BoothDescription(
     onAction: (BoothUiAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val activity = context.findActivity()
     val configuration = LocalConfiguration.current
     val maxWidth = remember(configuration) {
         val screenWidth = configuration.screenWidthDp.dp - 40.dp
@@ -187,11 +185,7 @@ internal fun BoothDescription(
         Spacer(modifier = Modifier.height(16.dp))
         UnifestOutlinedButton(
             onClick = {
-                if (activity.checkLocationPermission()) {
-                    onAction(BoothUiAction.OnCheckLocationClick)
-                } else {
-                    onAction(BoothUiAction.OnRequestLocationPermission)
-                }
+                onAction(BoothUiAction.OnCheckLocationClick)
             },
             modifier = Modifier.fillMaxWidth(),
         ) {

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
@@ -1,5 +1,6 @@
 package com.unifest.android.feature.booth.viewmodel
 
+import com.unifest.android.core.common.PermissionDialogButtonType
 import com.unifest.android.core.model.MenuModel
 
 sealed interface BoothUiAction {
@@ -25,6 +26,12 @@ sealed interface BoothUiAction {
     data object OnScheduleToggleClick : BoothUiAction
     data object OnMoveClick : BoothUiAction
     data object OnNoShowDialogCancelClick : BoothUiAction
+    data object OnRequestLocationPermission: BoothUiAction
+    data object OnRequestNotificationPermission: BoothUiAction
+    data class OnPermissionDialogButtonClick(
+        val buttonType: PermissionDialogButtonType,
+        val permission: String? = null,
+    ) : BoothUiAction
 }
 
 enum class ErrorType {

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
@@ -26,8 +26,8 @@ sealed interface BoothUiAction {
     data object OnScheduleToggleClick : BoothUiAction
     data object OnMoveClick : BoothUiAction
     data object OnNoShowDialogCancelClick : BoothUiAction
-    data object OnRequestLocationPermission: BoothUiAction
-    data object OnRequestNotificationPermission: BoothUiAction
+    data object OnRequestLocationPermission : BoothUiAction
+    data object OnRequestNotificationPermission : BoothUiAction
     data class OnPermissionDialogButtonClick(
         val buttonType: PermissionDialogButtonType,
         val permission: String? = null,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiEvent.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiEvent.kt
@@ -5,10 +5,11 @@ import com.unifest.android.core.common.UiText
 sealed interface BoothUiEvent {
     data object NavigateBack : BoothUiEvent
     data object NavigateToBoothLocation : BoothUiEvent
-    data class ShowSnackBar(val message: UiText) : BoothUiEvent
     data object NavigateToPrivatePolicy : BoothUiEvent
     data object NavigateToThirdPartyPolicy : BoothUiEvent
-    data class ShowToast(val message: UiText) : BoothUiEvent
     data object NavigateToAppSetting : BoothUiEvent
     data object NavigateToWaiting : BoothUiEvent
+    data class ShowSnackBar(val message: UiText) : BoothUiEvent
+    data class ShowToast(val message: UiText) : BoothUiEvent
+    data class RequestPermission(val permission: String) : BoothUiEvent
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -36,15 +36,15 @@ data class BoothUiState(
     val privacyConsentChecked: Boolean = false,
     val isScheduleExpanded: Boolean = false,
     val myWaitingList: ImmutableList<MyWaitingModel> = persistentListOf(),
-    val isLocationPermissionDialogVisible: Boolean = false,
     val isNotificationPermissionDialogVisible: Boolean = false,
+    val isLocationPermissionDialogVisible: Boolean = false,
     val outerPolygon: ImmutableList<LatLng> = persistentListOf(
         LatLng(50.0, 150.0),
         LatLng(50.0, 100.0),
         LatLng(30.0, 100.0),
         LatLng(30.0, 150.0),
     ),
-    val innerPolylines: ImmutableList<ImmutableList<LatLng>> = persistentListOf(
+    val innerPolyLines: ImmutableList<ImmutableList<LatLng>> = persistentListOf(
         KONKUK_UNIVERSITY_POLYLINE,
         HANKYONG_UNIVERSITY_POLYLINE,
         KOREA_NATIONAL_UNIVERSITY_OF_TRANSPORTATION_POLYLINE,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -75,8 +75,8 @@ class BoothViewModel @Inject constructor(
             is BoothUiAction.OnScheduleToggleClick -> toggleScheduleExpanded()
             is BoothUiAction.OnMoveClick -> navigateToWaiting()
             is BoothUiAction.OnNoShowDialogCancelClick -> setNoShowDialogVisible(false)
-            is BoothUiAction.OnRequestLocationPermission -> requestLocationPermission()
-            is BoothUiAction.OnRequestNotificationPermission -> requestNotificationPermission()
+            is BoothUiAction.OnRequestLocationPermission -> setLocationPermissionDialogVisible(true)
+            is BoothUiAction.OnRequestNotificationPermission -> setNotificationPermissionDialogVisible(true)
             is BoothUiAction.OnPermissionDialogButtonClick -> handlePermissionDialogButtonClick(action.buttonType, action.permission)
         }
     }
@@ -398,20 +398,6 @@ class BoothViewModel @Inject constructor(
     private fun setConfirmDialogVisible(flag: Boolean) {
         _uiState.update {
             it.copy(isConfirmDialogVisible = flag)
-        }
-    }
-
-    private fun requestLocationPermission() {
-        viewModelScope.launch {
-            _uiEvent.send(BoothUiEvent.RequestPermission(Manifest.permission.ACCESS_FINE_LOCATION))
-        }
-    }
-
-    private fun requestNotificationPermission() {
-        viewModelScope.launch {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                _uiEvent.send(BoothUiEvent.RequestPermission(Manifest.permission.POST_NOTIFICATIONS))
-            }
         }
     }
 

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -456,9 +456,7 @@ class BoothViewModel @Inject constructor(
 
     private fun dismissDialog(permission: String?) {
         when (permission) {
-            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION,
-                -> setLocationPermissionDialogVisible(false)
-
+            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION -> setLocationPermissionDialogVisible(false)
             Manifest.permission.POST_NOTIFICATIONS -> setNotificationPermissionDialogVisible(false)
         }
     }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -75,7 +75,7 @@ class BoothViewModel @Inject constructor(
             is BoothUiAction.OnScheduleToggleClick -> toggleScheduleExpanded()
             is BoothUiAction.OnMoveClick -> navigateToWaiting()
             is BoothUiAction.OnNoShowDialogCancelClick -> setNoShowDialogVisible(false)
-            is BoothUiAction.OnRequestLocationPermission -> setLocationPermissionDialogVisible(true)
+            is BoothUiAction.OnRequestLocationPermission -> navigateToBoothLocation()
             is BoothUiAction.OnRequestNotificationPermission -> setNotificationPermissionDialogVisible(true)
             is BoothUiAction.OnPermissionDialogButtonClick -> handlePermissionDialogButtonClick(action.buttonType, action.permission)
         }
@@ -405,13 +405,19 @@ class BoothViewModel @Inject constructor(
         viewModelScope.launch {
             when (permission) {
                 Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION -> {
-                    if (isGranted) {
-                        navigateToBoothLocation()
+                    if (!isGranted) {
+                        setLocationPermissionDialogVisible(true)
+                    } else {
+                        setLocationPermissionDialogVisible(false)
                     }
                 }
 
                 Manifest.permission.POST_NOTIFICATIONS -> {
-                    checkMyWaitingListNumbers()
+                    if (!isGranted) {
+                        setNotificationPermissionDialogVisible(true)
+                    } else {
+                        checkMyWaitingListNumbers()
+                    }
                 }
             }
         }
@@ -447,15 +453,15 @@ class BoothViewModel @Inject constructor(
         }
     }
 
-    private fun setLocationPermissionDialogVisible(flag: Boolean) {
-        _uiState.update {
-            it.copy(isLocationPermissionDialogVisible = flag)
-        }
-    }
-
     private fun setNotificationPermissionDialogVisible(flag: Boolean) {
         _uiState.update {
             it.copy(isNotificationPermissionDialogVisible = flag)
+        }
+    }
+
+    private fun setLocationPermissionDialogVisible(flag: Boolean) {
+        _uiState.update {
+            it.copy(isLocationPermissionDialogVisible = flag)
         }
     }
 

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -1,10 +1,13 @@
 package com.unifest.android.feature.booth.viewmodel
 
+import android.Manifest
+import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.unifest.android.core.common.ErrorHandlerActions
+import com.unifest.android.core.common.PermissionDialogButtonType
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.handleException
 import com.unifest.android.core.data.api.repository.BoothRepository
@@ -72,6 +75,9 @@ class BoothViewModel @Inject constructor(
             is BoothUiAction.OnScheduleToggleClick -> toggleScheduleExpanded()
             is BoothUiAction.OnMoveClick -> navigateToWaiting()
             is BoothUiAction.OnNoShowDialogCancelClick -> setNoShowDialogVisible(false)
+            is BoothUiAction.OnRequestLocationPermission -> requestLocationPermission()
+            is BoothUiAction.OnRequestNotificationPermission -> requestNotificationPermission()
+            is BoothUiAction.OnPermissionDialogButtonClick -> handlePermissionDialogButtonClick(action.buttonType, action.permission)
         }
     }
 
@@ -392,6 +398,80 @@ class BoothViewModel @Inject constructor(
     private fun setConfirmDialogVisible(flag: Boolean) {
         _uiState.update {
             it.copy(isConfirmDialogVisible = flag)
+        }
+    }
+
+    private fun requestLocationPermission() {
+        viewModelScope.launch {
+            _uiEvent.send(BoothUiEvent.RequestPermission(Manifest.permission.ACCESS_FINE_LOCATION))
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        viewModelScope.launch {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                _uiEvent.send(BoothUiEvent.RequestPermission(Manifest.permission.POST_NOTIFICATIONS))
+            }
+        }
+    }
+
+    fun onPermissionResult(permission: String, isGranted: Boolean) {
+        viewModelScope.launch {
+            when (permission) {
+                Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION -> {
+                    if (isGranted) {
+                        navigateToBoothLocation()
+                    }
+                }
+
+                Manifest.permission.POST_NOTIFICATIONS -> {
+                    checkMyWaitingListNumbers()
+                }
+            }
+        }
+    }
+
+    private fun handlePermissionDialogButtonClick(buttonType: PermissionDialogButtonType, permission: String?) {
+        when (buttonType) {
+            PermissionDialogButtonType.DISMISS -> {
+                dismissDialog(permission)
+            }
+
+            PermissionDialogButtonType.NAVIGATE_TO_APP_SETTING -> {
+                viewModelScope.launch {
+                    _uiEvent.send(BoothUiEvent.NavigateToAppSetting)
+                }
+            }
+
+            PermissionDialogButtonType.CONFIRM -> {
+                dismissDialog(permission)
+                viewModelScope.launch {
+                    if (permission != null) {
+                        _uiEvent.send(BoothUiEvent.RequestPermission(permission))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun dismissDialog(permission: String?) {
+        when (permission) {
+            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION,
+                -> setLocationPermissionDialogVisible(false)
+
+            Manifest.permission.POST_NOTIFICATIONS -> setNotificationPermissionDialogVisible(false)
+        }
+    }
+
+    private fun setLocationPermissionDialogVisible(flag: Boolean) {
+        _uiState.update {
+            it.copy(isLocationPermissionDialogVisible = flag)
+        }
+    }
+
+    private fun setNotificationPermissionDialogVisible(flag: Boolean) {
+        _uiState.update {
+            it.copy(isNotificationPermissionDialogVisible = flag)
         }
     }
 

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -80,6 +80,7 @@ import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.PermissionDialogButtonType
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.extension.checkLocationPermission
+import com.unifest.android.core.common.extension.checkNotificationPermission
 import com.unifest.android.core.common.extension.findActivity
 import com.unifest.android.core.designsystem.MarkerCategory
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
@@ -142,13 +143,7 @@ internal fun MapRoute(
     }
 
     var isNotificationPermissionGranted by remember {
-        mutableStateOf(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                activity.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-            } else {
-                true
-            },
-        )
+        mutableStateOf(activity.checkNotificationPermission())
     }
 
     val permissionResultLauncher = rememberLauncherForActivityResult(
@@ -179,18 +174,18 @@ internal fun MapRoute(
         onResult = {
             // 설정에서 돌아왔을 때 권한 상태를 다시 확인
             isLocationPermissionGranted = activity.checkLocationPermission()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                isNotificationPermissionGranted =
-                    activity.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-            }
-            mapViewModel.onPermissionResult(
-                permission = Manifest.permission.ACCESS_FINE_LOCATION,
-                isGranted = isLocationPermissionGranted,
-            )
+            isNotificationPermissionGranted = activity.checkNotificationPermission()
+
             mapViewModel.onPermissionResult(
                 permission = Manifest.permission.ACCESS_COARSE_LOCATION,
                 isGranted = isLocationPermissionGranted,
             )
+
+            mapViewModel.onPermissionResult(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                isGranted = isLocationPermissionGranted,
+            )
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 mapViewModel.onPermissionResult(
                     permission = Manifest.permission.POST_NOTIFICATIONS,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -2,7 +2,6 @@ package com.unifest.android.feature.map
 
 import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -377,9 +377,10 @@ internal fun MapContent(
                 isNightModeEnabled = isSystemInDarkTheme(),
             ),
             uiSettings = MapUiSettings(
-                isZoomControlEnabled = false,
+                isZoomControlEnabled = true,
                 isScaleBarEnabled = false,
                 isLogoClickEnabled = false,
+                isLocationButtonEnabled = true,
             ),
             locationSource = rememberFusedLocationSource(),
         ) {

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiEvent.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiEvent.kt
@@ -3,9 +3,8 @@ package com.unifest.android.feature.map.viewmodel
 import com.unifest.android.core.common.UiText
 
 sealed interface MapUiEvent {
-    data object RequestPermissions : MapUiEvent
-    data class RequestPermission(val permission: String) : MapUiEvent
     data object NavigateToAppSetting : MapUiEvent
     data class NavigateToBoothDetail(val boothId: Long) : MapUiEvent
     data class ShowSnackBar(val message: UiText) : MapUiEvent
+    data object RequestNotificationPermission : MapUiEvent
 }

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -28,7 +28,6 @@ data class MapUiState(
     val isMapOnboardingCompleted: Boolean = false,
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
-    val isPermissionDialogVisible: Boolean = false,
     val outerPolygon: ImmutableList<LatLng> = persistentListOf(
         LatLng(50.0, 150.0),
         LatLng(50.0, 100.0),

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -28,13 +28,15 @@ data class MapUiState(
     val isMapOnboardingCompleted: Boolean = false,
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
+    val isNotificationPermissionDialogVisible: Boolean = false,
+    val isLocationPermissionDialogVisible: Boolean = false,
     val outerPolygon: ImmutableList<LatLng> = persistentListOf(
         LatLng(50.0, 150.0),
         LatLng(50.0, 100.0),
         LatLng(30.0, 100.0),
         LatLng(30.0, 150.0),
     ),
-    val innerPolylines: ImmutableList<ImmutableList<LatLng>> = persistentListOf(
+    val innerPolyLines: ImmutableList<ImmutableList<LatLng>> = persistentListOf(
         KONKUK_UNIVERSITY_POLYLINE,
         HANKYONG_UNIVERSITY_POLYLINE,
         KOREA_NATIONAL_UNIVERSITY_OF_TRANSPORTATION_POLYLINE,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -58,13 +58,13 @@ class MapViewModel @Inject constructor(
     }
 
     init {
-        requestLocationPermission()
+        requestPermissions()
         getRecentLikedFestivalStream()
         getAllFestivals()
         checkMapOnboardingCompletion()
     }
 
-    private fun requestLocationPermission() {
+    private fun requestPermissions() {
         viewModelScope.launch {
             _uiEvent.send(MapUiEvent.RequestPermissions)
         }

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/StampScreen.kt
@@ -189,7 +189,7 @@ internal fun StampScreen(
 
         if (uiState.isStampBoothDialogVisible) {
             StampBoothBottomSheet(
-                schoolName = uiState.selectedFestival.name,
+                schoolName = uiState.selectedFestival.schoolName,
                 stampBoothList = uiState.stampBoothList,
                 onAction = onAction,
             )

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/SchoolsDropDownMenu.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/SchoolsDropDownMenu.kt
@@ -78,7 +78,7 @@ internal fun SchoolsDropDownMenu(
         ) {
             Spacer(modifier = Modifier.width(25.dp))
             Text(
-                text = selectedFestival.name,
+                text = selectedFestival.schoolName,
                 modifier = Modifier.weight(1f),
                 color = MaterialTheme.colorScheme.onBackground,
                 maxLines = 1,
@@ -138,7 +138,7 @@ internal fun SchoolsDropDownMenu(
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
                                     Text(
-                                        text = school.name,
+                                        text = school.schoolName,
                                         style = StampSchools,
                                         color = MaterialTheme.colorScheme.inverseOnSurface,
                                     )

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampItem.kt
@@ -61,7 +61,7 @@ private fun StampItemPreview() {
             collectedStampCount = 10,
             selectedFestival = StampFestivalModel(
                 festivalId = 1,
-                name = "축제",
+                schoolName = "축제",
                 defaultImgUrl = "",
                 usedImgUrl = "",
             ),

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -120,7 +120,7 @@ class StampViewModel @Inject constructor(
                     currentState.copy(
                         selectedFestival = matchingFestival ?: StampFestivalModel(
                             festivalId = recentLikedFestival.festivalId,
-                            name = recentLikedFestival.schoolName,
+                            schoolName = recentLikedFestival.schoolName,
                             defaultImgUrl = "",
                             usedImgUrl = "",
                         ),


### PR DESCRIPTION
feat)
- 맵 화면 내에 축소,확대 버튼 및 내 위치 확인 버튼 추가 


refactor)
- 권한 관련 로직 개선
  -> NaverMap 내부에서 진입시 위치 권한 허용 요청을 트리거 하는 관계로 명시적인 위치 권한 허용 요청 제거
  -> 영구 거부 관련 팝업 호출(설정 이동)만 처리(정상 동작하는지 테스트 해봐야함)
  
fix)
- 스탬프 API response 변경 사항 반영(축제 이름 -> 학교 이름)