### PR TITLE
[fix] github action cd workflow

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -44,8 +44,11 @@ jobs:
             -   name: Generate debug.keystore
                 run: echo '${{ secrets.DEBUG_KEYSTORE }}' | base64 -d > ./debug.keystore
 
-            -   name: Extract Version Name
-                run: echo "##[set-output name=version;]v$(echo '${{ github.event.pull_request.title }}' | grep -oP 'release v\K[0-9]+\.[0-9]+\.[0-9]+')"
+            -   name: Extract Version Name from libs.versions.toml
+                run: |
+                    VERSION=$(grep -P 'versionName\s*=\s*"([^"]+)"' gradle/libs.versions.toml | grep -oP '(?<=").*(?=")')
+                    echo "version=v$VERSION" >> $GITHUB_OUTPUT
+                    echo "Version extracted from toml: v$VERSION"
                 id: extract_version
 
             -   name: Build Debug APK

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "31"
+versionCode = "32"
 versionName = "1.3.4"
 packageName = "com.unifest.android"
 


### PR DESCRIPTION
fix)
- cd workflow 내에 버전 추출 로직 변경
-> PR Title 내에 버전 추출 -> libs.versions.toml 내에 versionName 추출로 변경하여 PR Title을 작성하는 사람의 실수(휴먼 에러)를 방지