### PR TITLE
[fix] 맵화면내에 리프 마커에 클러스터링 마커의 captionText가 남아있던 문제 해결 

### DIFF
--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -479,6 +479,8 @@ internal fun MapContent(
                             .leafMarkerUpdater { info, marker ->
                                 marker.icon = MarkerCategory.fromString((info.key as BoothMapModel).category)
                                     .getMarkerIcon((info.key as BoothMapModel).isSelected)
+                                marker.captionText = ""
+                                marker.subCaptionText = ""
                                 marker.onClickListener = Overlay.OnClickListener {
                                     onMapUiAction(MapUiAction.OnBoothMarkerClick(listOf(info.key as BoothMapModel)))
                                     true

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -338,7 +338,7 @@ internal fun MapScreen(
     RememberedEffect(key1 = mapUiState.festivalInfo) {
         if (mapUiState.festivalInfo.latitude != 0.0F && mapUiState.festivalInfo.longitude != 0.0F) {
             cameraPositionState.position = CameraPosition(
-                LatLng(mapUiState.festivalInfo.latitude.toDouble(), mapUiState.festivalInfo.longitude.toDouble()), 15.2,
+                LatLng(mapUiState.festivalInfo.latitude.toDouble(), mapUiState.festivalInfo.longitude.toDouble()), 15.7,
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "34"
-versionName = "1.3.6"
+versionCode = "35"
+versionName = "1.3.7"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"


### PR DESCRIPTION
NaverMap의 마커는 재사용되기 때문에, 이전에 세팅된 caption이나, 기타 속성들이 새로운 마커에 남아있게 됨
따라서 이 값들을 명시적으로 덮어씌워 문제를 해결(captionText = "")
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 지도에서 부스 마커의 캡션과 서브캡션 텍스트가 표시되지 않도록 변경되었습니다.
  - 축제 위치의 지도 초기 확대 수준이 소폭 조정되었습니다.

- **Chores**
  - 앱 버전이 1.3.7(35)로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->