### PR TITLE
[fix] Intro 화면내에 관심 축제로 추가된 축제, 축제 기간 텍스트가 잘리는 문제 해결

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/AutoResizedText.kt
@@ -1,5 +1,6 @@
 package com.unifest.android.core.designsystem.component
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -12,6 +13,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.isUnspecified
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.theme.Content4
+import com.unifest.android.core.designsystem.theme.UnifestTheme
 
 @Composable
 fun AutoResizedText(
@@ -56,4 +60,17 @@ fun AutoResizedText(
         },
         style = resizedTextStyle,
     )
+}
+
+@ComponentPreview
+@Composable
+private fun AutoResizedTextPreview() {
+    UnifestTheme {
+        AutoResizedText(
+            text = "Hello World Hello World Hello World",
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            style = Content4,
+        )
+    }
 }

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalItem.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalItem.kt
@@ -1,0 +1,138 @@
+package com.unifest.android.core.ui.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.common.utils.formatToString
+import com.unifest.android.core.common.utils.toLocalDate
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.R as designR
+import com.unifest.android.core.designsystem.component.AutoResizedText
+import com.unifest.android.core.designsystem.component.NetworkImage
+import com.unifest.android.core.designsystem.theme.Content2
+import com.unifest.android.core.designsystem.theme.Content3
+import com.unifest.android.core.designsystem.theme.Content4
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.FestivalModel
+
+@Composable
+fun FestivalItem(
+    festival: FestivalModel,
+    onFestivalSelected: (FestivalModel) -> Unit,
+    modifier: Modifier = Modifier,
+    isEditMode: Boolean = false,
+    setLikedFestivalDeleteDialogVisible: (FestivalModel) -> Unit = {},
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.scrim),
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .clickable {
+                    if (isEditMode) {
+                        setLikedFestivalDeleteDialogVisible(festival)
+                    } else {
+                        onFestivalSelected(festival)
+                    }
+                },
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            ) {
+                NetworkImage(
+                    imgUrl = festival.thumbnail,
+                    contentDescription = "Festival Thumbnail",
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape),
+                    placeholder = painterResource(id = designR.drawable.item_placeholder),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                AutoResizedText(
+                    text = festival.schoolName,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
+                    style = Content2,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                AutoResizedText(
+                    text = festival.festivalName,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
+                    style = Content4,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = Content3,
+                )
+            }
+            if (isEditMode) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = designR.drawable.ic_delete_red),
+                    contentDescription = "Delete Icon",
+                    tint = Color.Unspecified,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 6.dp, end = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun FestivalItemPreview() {
+    UnifestTheme {
+        FestivalItem(
+            festival = FestivalModel(
+                1,
+                1,
+                "https://picsum.photos/36",
+                "서울대학교",
+                "서울",
+                "설대축제",
+                "2024-04-21",
+                "2024-04-23",
+                126.957f,
+                37.460f,
+            ),
+            onFestivalSelected = {},
+        )
+    }
+}

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalItem.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/FestivalItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.utils.formatToString
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.ComponentPreview
-import com.unifest.android.core.designsystem.R as designR
 import com.unifest.android.core.designsystem.component.AutoResizedText
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content2
@@ -39,6 +37,7 @@ import com.unifest.android.core.designsystem.theme.Content3
 import com.unifest.android.core.designsystem.theme.Content4
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.FestivalModel
+import com.unifest.android.core.designsystem.R as designR
 
 @Composable
 fun FestivalItem(
@@ -95,9 +94,10 @@ fun FestivalItem(
                     style = Content4,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                AutoResizedText(
                     text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
                     style = Content3,
                 )
             }

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
@@ -2,47 +2,17 @@ package com.unifest.android.core.ui.component
 
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.unifest.android.core.common.utils.formatToString
-import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.ComponentPreview
-import com.unifest.android.core.designsystem.component.AutoResizedText
-import com.unifest.android.core.designsystem.R as designR
-import com.unifest.android.core.designsystem.component.NetworkImage
-import com.unifest.android.core.designsystem.theme.Content2
-import com.unifest.android.core.designsystem.theme.Content3
-import com.unifest.android.core.designsystem.theme.Content4
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
@@ -85,103 +55,6 @@ fun LikedFestivalsGrid(
                 )
             }
         }
-    }
-}
-
-@Composable
-fun FestivalItem(
-    festival: FestivalModel,
-    onFestivalSelected: (FestivalModel) -> Unit,
-    modifier: Modifier = Modifier,
-    isEditMode: Boolean = false,
-    setLikedFestivalDeleteDialogVisible: (FestivalModel) -> Unit = {},
-) {
-    Card(
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.scrim),
-        modifier = modifier,
-    ) {
-        Box(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .clickable {
-                    if (isEditMode) {
-                        setLikedFestivalDeleteDialogVisible(festival)
-                    } else {
-                        onFestivalSelected(festival)
-                    }
-                },
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
-            ) {
-                NetworkImage(
-                    imgUrl = festival.thumbnail,
-                    contentDescription = "Festival Thumbnail",
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clip(CircleShape),
-                    placeholder = painterResource(id = designR.drawable.item_placeholder),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                AutoResizedText(
-                    text = festival.schoolName,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    textAlign = TextAlign.Center,
-                    style = Content2,
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                AutoResizedText(
-                    text = festival.festivalName,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    textAlign = TextAlign.Center,
-                    style = Content4,
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = Content3,
-                )
-            }
-            if (isEditMode) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = designR.drawable.ic_delete_red),
-                    contentDescription = "Delete Icon",
-                    tint = Color.Unspecified,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 6.dp, end = 6.dp),
-                )
-            }
-        }
-    }
-}
-
-@ComponentPreview
-@Composable
-private fun FestivalItemPreview() {
-    UnifestTheme {
-        FestivalItem(
-            festival = FestivalModel(
-                1,
-                1,
-                "https://picsum.photos/36",
-                "서울대학교",
-                "서울",
-                "설대축제",
-                "2024-04-21",
-                "2024-04-23",
-                126.957f,
-                37.460f,
-            ),
-            onFestivalSelected = {},
-        )
     }
 }
 

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.utils.formatToString
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.component.AutoResizedText
 import com.unifest.android.core.designsystem.R as designR
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content2
@@ -128,14 +129,14 @@ fun FestivalItem(
                     placeholder = painterResource(id = designR.drawable.item_placeholder),
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                Text(
+                AutoResizedText(
                     text = festival.schoolName,
                     color = MaterialTheme.colorScheme.onBackground,
                     textAlign = TextAlign.Center,
                     style = Content2,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                AutoResizedText(
                     text = festival.festivalName,
                     color = MaterialTheme.colorScheme.onBackground,
                     textAlign = TextAlign.Center,
@@ -143,7 +144,7 @@ fun FestivalItem(
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
+                    text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = Content3,
                 )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
@@ -116,49 +116,51 @@ internal fun BoothDescription(
             color = MaterialTheme.colorScheme.onSecondary,
             style = Content2.copy(lineHeight = 18.sp),
         )
-        Spacer(modifier = Modifier.height(22.dp))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .clickable { onAction(BoothUiAction.OnScheduleToggleClick) },
-        ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(id = R.drawable.ic_clock),
-                contentDescription = "location icon",
-                tint = Color.Unspecified,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = if (isBoothRunning) stringResource(id = R.string.booth_is_running)
-                else stringResource(id = R.string.booth_is_closed),
-                color = MaterialTheme.colorScheme.onBackground,
-                style = BoothLocation,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Icon(
-                imageVector = ImageVector.vectorResource(designR.drawable.ic_arrow_below),
-                contentDescription = "Arrow Down",
-                tint = Color.Unspecified,
-            )
-        }
-        AnimatedVisibility(visible = isScheduleExpanded) {
-            LazyColumn(
+        if (scheduleList.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(22.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .height((23 * scheduleList.size).dp)
-                    .padding(start = 24.dp),
-                contentPadding = PaddingValues(vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(7.dp),
+                    .padding(top = 8.dp)
+                    .clickable { onAction(BoothUiAction.OnScheduleToggleClick) },
             ) {
-                items(
-                    items = scheduleList,
-                    key = { it.id },
-                ) { schedule ->
-                    Text(
-                        text = schedule.toFormattedString(),
-                        color = MaterialTheme.colorScheme.onBackground,
-                        style = BoothLocation,
-                    )
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_clock),
+                    contentDescription = "location icon",
+                    tint = Color.Unspecified,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = if (isBoothRunning) stringResource(id = R.string.booth_is_running)
+                    else stringResource(id = R.string.booth_is_closed),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = BoothLocation,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(
+                    imageVector = ImageVector.vectorResource(designR.drawable.ic_arrow_below),
+                    contentDescription = "Arrow Down",
+                    tint = Color.Unspecified,
+                )
+            }
+            AnimatedVisibility(visible = isScheduleExpanded) {
+                LazyColumn(
+                    modifier = Modifier
+                        .height((23 * scheduleList.size).dp)
+                        .padding(start = 24.dp),
+                    contentPadding = PaddingValues(vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(7.dp),
+                ) {
+                    items(
+                        items = scheduleList,
+                        key = { it.id },
+                    ) { schedule ->
+                        Text(
+                            text = schedule.toFormattedString(),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            style = BoothLocation,
+                        )
+                    }
                 }
             }
         }
@@ -218,6 +220,22 @@ private fun BoothDescriptionPreview() {
                     closeTime = "18:00:00",
                 ),
             ),
+            onAction = {},
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun BoothDescriptionNoSchedulePreview() {
+    UnifestTheme {
+        BoothDescription(
+            name = "공대주점",
+            warning = "누구나 환영",
+            description = "컴퓨터 공학과와 물리학과가 함께하는 협동부스입니다. 방문자 이벤트로 무료 안주 하나씩 제공중이에요!!",
+            location = "공학관",
+            isScheduleExpanded = false,
+            scheduleList = persistentListOf(),
             onAction = {},
         )
     }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothDescription.kt
@@ -198,7 +198,23 @@ internal fun BoothDescription(
 
 @ComponentPreview
 @Composable
-private fun BoothDescriptionPreview() {
+private fun BoothDescriptionNoSchedulePreview() {
+    UnifestTheme {
+        BoothDescription(
+            name = "공대주점",
+            warning = "누구나 환영",
+            description = "컴퓨터 공학과와 물리학과가 함께하는 협동부스입니다. 방문자 이벤트로 무료 안주 하나씩 제공중이에요!!",
+            location = "공학관",
+            isScheduleExpanded = false,
+            scheduleList = persistentListOf(),
+            onAction = {},
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun BoothDescriptionClosedPreview() {
     UnifestTheme {
         BoothDescription(
             name = "공대주점",
@@ -227,7 +243,7 @@ private fun BoothDescriptionPreview() {
 
 @ComponentPreview
 @Composable
-private fun BoothDescriptionNoSchedulePreview() {
+private fun BoothDescriptionOpenPreview() {
     UnifestTheme {
         BoothDescription(
             name = "공대주점",
@@ -235,7 +251,49 @@ private fun BoothDescriptionNoSchedulePreview() {
             description = "컴퓨터 공학과와 물리학과가 함께하는 협동부스입니다. 방문자 이벤트로 무료 안주 하나씩 제공중이에요!!",
             location = "공학관",
             isScheduleExpanded = false,
-            scheduleList = persistentListOf(),
+            scheduleList = persistentListOf(
+                ScheduleModel(
+                    id = 14,
+                    date = "2025-05-07",
+                    openTime = "10:00:00",
+                    closeTime = "18:00:00",
+                ),
+                ScheduleModel(
+                    id = 15,
+                    date = "2025-05-08",
+                    openTime = "10:00:00",
+                    closeTime = "18:00:00",
+                ),
+            ),
+            onAction = {},
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun BoothDescriptionOpenDropdownExpandedPreview() {
+    UnifestTheme {
+        BoothDescription(
+            name = "공대주점",
+            warning = "누구나 환영",
+            description = "컴퓨터 공학과와 물리학과가 함께하는 협동부스입니다. 방문자 이벤트로 무료 안주 하나씩 제공중이에요!!",
+            location = "공학관",
+            isScheduleExpanded = true,
+            scheduleList = persistentListOf(
+                ScheduleModel(
+                    id = 14,
+                    date = "2025-05-07",
+                    openTime = "10:00:00",
+                    closeTime = "18:00:00",
+                ),
+                ScheduleModel(
+                    id = 15,
+                    date = "2025-05-08",
+                    openTime = "10:00:00",
+                    closeTime = "18:00:00",
+                ),
+            ),
             onAction = {},
         )
     }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
@@ -67,9 +67,10 @@ internal fun FestivalRowItem(
                         .clip(CircleShape),
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                Text(
+                AutoResizedText(
                     text = festival.schoolName,
                     color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
                     style = Content2,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
@@ -81,7 +82,7 @@ internal fun FestivalRowItem(
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
+                    text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = Content3,
                 )

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,9 +80,10 @@ internal fun FestivalRowItem(
                     style = Content4,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                AutoResizedText(
                     text = "${festival.beginDate.toLocalDate().formatToString()} - ${festival.endDate.toLocalDate().formatToString()}",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
                     style = Content3,
                 )
             }

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/component/FestivalRowItem.kt
@@ -21,10 +21,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.utils.formatToString
 import com.unifest.android.core.common.utils.toLocalDate
 import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.component.AutoResizedText
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Content3
@@ -37,14 +39,13 @@ import com.unifest.android.feature.intro.viewmodel.IntroUiAction
 internal fun FestivalRowItem(
     festival: FestivalModel,
     onAction: (IntroUiAction) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Card(
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
-        modifier = Modifier
-            .height(130.dp)
-            .width(120.dp),
+        modifier = modifier.width(120.dp),
     ) {
         Box(
             modifier = Modifier.clickable {
@@ -72,9 +73,10 @@ internal fun FestivalRowItem(
                     style = Content2,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                AutoResizedText(
                     text = festival.festivalName,
                     color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
                     style = Content4,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
@@ -99,7 +101,7 @@ private fun FestivalRowItemPreview() {
                 "https://picsum.photos/36",
                 "서울대학교",
                 "서울",
-                "설대축제",
+                "설대축제설대축제설대축제설대축제",
                 "2024-04-21",
                 "2024-04-23",
                 126.957f,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -468,22 +468,25 @@ internal fun MapContent(
                                 },
                             )
                             .clusterMarkerUpdater { info, marker ->
-                                val size = info.size
-                                marker.icon = OverlayImage.fromResource(designR.drawable.ic_cluster)
-                                marker.captionText = size.toString()
-                                marker.setCaptionAligns(Align.Center)
-                                marker.captionColor = android.graphics.Color.WHITE
-                                marker.captionHaloColor = android.graphics.Color.TRANSPARENT
-                                marker.onClickListener = DefaultClusterOnClickListener(info)
+                                marker.apply {
+                                    icon = OverlayImage.fromResource(designR.drawable.ic_cluster)
+                                    captionText = info.size.toString()
+                                    setCaptionAligns(Align.Center)
+                                    captionColor = android.graphics.Color.WHITE
+                                    captionHaloColor = android.graphics.Color.TRANSPARENT
+                                    onClickListener = DefaultClusterOnClickListener(info)
+                                }
                             }
                             .leafMarkerUpdater { info, marker ->
-                                marker.icon = MarkerCategory.fromString((info.key as BoothMapModel).category)
-                                    .getMarkerIcon((info.key as BoothMapModel).isSelected)
-                                marker.captionText = ""
-                                marker.subCaptionText = ""
-                                marker.onClickListener = Overlay.OnClickListener {
-                                    onMapUiAction(MapUiAction.OnBoothMarkerClick(listOf(info.key as BoothMapModel)))
-                                    true
+                                marker.apply {
+                                    icon = MarkerCategory.fromString((info.key as BoothMapModel).category)
+                                        .getMarkerIcon((info.key as BoothMapModel).isSelected)
+                                    captionText = ""
+                                    subCaptionText = ""
+                                    onClickListener = Overlay.OnClickListener {
+                                        onMapUiAction(MapUiAction.OnBoothMarkerClick(listOf(info.key as BoothMapModel)))
+                                        true
+                                    }
                                 }
                             }
                             .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "36"
-versionName = "1.3.8"
+versionCode = "37"
+versionName = "1.3.9"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 텍스트 자동 크기 조절 기능을 미리 볼 수 있는 프리뷰가 추가되었습니다.
  - 축제 정보를 카드 형식으로 보여주는 새로운 FestivalItem 컴포넌트가 도입되었습니다.
  - 일정이 없는 부스 설명에서 일정 토글과 리스트가 표시되지 않도록 개선되었습니다.
- **Refactor**
  - FestivalRowItem의 레이아웃 유연성이 개선되고, 텍스트가 자동으로 크기 조절되는 컴포넌트로 변경되었습니다.
  - 지도 클러스터 및 마커 설정 코드가 더 간결하고 읽기 쉽게 개선되었습니다.
- **Chores**
  - 앱 버전이 1.3.9(37)로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->