### PR TITLE
[refactor] QRScan 화면내 festivalId 뷰모델내에 savedStateHandle 로 받는 방식으로 변경 처리

### DIFF
--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/QRScanActivity.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/QRScanActivity.kt
@@ -54,13 +54,10 @@ internal class QRScanActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        val festivalId = intent.getLongExtra("festivalId", 0L)
-
         setContent {
             UnifestTheme {
                 QRScanScreen(
                     barcodeView = barcodeView,
-                    festivalId = festivalId,
                     popBackStack = {
                         setResult(RESULT_CANCELED)
                         finish()

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/QRScanScreen.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/QRScanScreen.kt
@@ -47,7 +47,6 @@ import com.unifest.android.core.designsystem.R as designR
 @Composable
 internal fun QRScanScreen(
     barcodeView: DecoratedBarcodeView,
-    festivalId: Long,
     popBackStack: () -> Unit,
     complete: () -> Unit,
     onAction: (QRScanUiAction) -> Unit,
@@ -65,7 +64,7 @@ internal fun QRScanScreen(
             is QRScanUiEvent.NavigateBack -> popBackStack()
             is QRScanUiEvent.RegisterStampCompleted -> complete()
             is QRScanUiEvent.RegisterStampFailed -> popBackStack()
-            is QRScanUiEvent.ScanSuccess -> viewModel.registerStamp(event.entryCode.toLong(), festivalId)
+            is QRScanUiEvent.ScanSuccess -> viewModel.registerStamp(event.entryCode.toLong())
             is QRScanUiEvent.ShowToast -> {
                 Toast.makeText(context, event.text.asString(context), Toast.LENGTH_SHORT).show()
             }

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/qrscan/QRScanViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/qrscan/QRScanViewModel.kt
@@ -1,5 +1,6 @@
 package com.unifest.android.feature.stamp.viewmodel.qrscan
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.QRScanErrorHandlerActions
@@ -22,7 +23,15 @@ import javax.inject.Inject
 @HiltViewModel
 class QRScanViewModel @Inject constructor(
     private val stampRepository: StampRepository,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel(), QRScanErrorHandlerActions {
+    companion object {
+        private const val FESTIVAL_ID = "festivalId"
+    }
+
+    private val festivalId: Long =
+        requireNotNull(savedStateHandle.get<Long>(FESTIVAL_ID)) { "festivalId is required" }
+
     private val _uiState = MutableStateFlow(QRScanUiState())
     val uiState: StateFlow<QRScanUiState> = _uiState.asStateFlow()
 
@@ -35,7 +44,7 @@ class QRScanViewModel @Inject constructor(
         }
     }
 
-    fun registerStamp(boothId: Long, festivalId: Long) {
+    fun registerStamp(boothId: Long) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             stampRepository.registerStamp(boothId, festivalId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - QR 코드 스캔 화면에서 festivalId를 내부적으로 처리하도록 변경하여, 화면 및 함수에서 festivalId 전달이 필요 없도록 개선되었습니다.  
  - QR 코드 등록 기능의 사용 방식이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->