### PR TITLE
[fix] M3 ModalBottomSheet UX/UI 개선(스크롤 버벅임 해결, 상단 패딩 적용)

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/CircularOutlineButton.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/CircularOutlineButton.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -14,9 +12,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.common.extension.noRippleClickable
 import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.R
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 
 @Composable
@@ -48,7 +48,7 @@ fun CircularOutlineButton(
 private fun CircularOutlineButtonPreview() {
     UnifestTheme {
         CircularOutlineButton(
-            icon = Icons.Default.Remove,
+            icon = ImageVector.vectorResource(id = R.drawable.ic_minus),
             contentDescription = "Minus Button",
             onClick = {},
         )

--- a/core/designsystem/src/main/res/drawable/ic_minus.xml
+++ b/core/designsystem/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="7dp"
+    android:height="2dp"
+    android:viewportWidth="7"
+    android:viewportHeight="2">
+  <path
+      android:pathData="M6.2266,0.3203V1.5703H0.2891V0.3203H6.2266Z"
+      android:fillColor="#4B4B4B"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_plus.xml
+++ b/core/designsystem/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="9dp"
+    android:viewportWidth="10"
+    android:viewportHeight="9">
+  <path
+      android:pathData="M4.547,8.887V5.098H0.777V3.828H4.547V0.059H5.816V3.828H9.605V5.098H5.816V8.887H4.547Z"
+      android:fillColor="#4B4B4B"/>
+</vector>

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/LikedFestivalGrid.kt
@@ -46,8 +46,8 @@ fun LikedFestivalsGrid(
                     },
                     isEditMode = isEditMode,
                     setLikedFestivalDeleteDialogVisible = onDeleteLikedFestivalClick,
-                    modifier = Modifier.animateItemPlacement(
-                        animationSpec = tween(
+                    modifier = Modifier.animateItem(
+                        placementSpec = tween(
                             durationMillis = 500,
                             easing = LinearOutSlowInEasing,
                         ),

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -21,9 +21,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -255,7 +252,7 @@ fun WaitingDialog(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     CircularOutlineButton(
-                        icon = Icons.Default.Remove,
+                        icon = ImageVector.vectorResource(id = designR.drawable.ic_minus),
                         contentDescription = "Minus Button",
                         onClick = onWaitingMinusClick,
                     )
@@ -267,7 +264,7 @@ fun WaitingDialog(
                     )
                     Spacer(modifier = Modifier.width(20.dp))
                     CircularOutlineButton(
-                        icon = Icons.Default.Add,
+                        icon = ImageVector.vectorResource(id = designR.drawable.ic_plus),
                         contentDescription = "Plus Button",
                         onClick = onWaitingPlusClick,
                     )

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,18 +49,7 @@ fun FestivalSearchBottomSheet(
     onFestivalUiAction: (FestivalUiAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-//    val bottomSheetState = rememberFlexibleBottomSheetState(
-//        containSystemBars = true,
-//        flexibleSheetSize = FlexibleSheetSize(
-//            intermediatelyExpanded = 1.0f,
-//        ),
-//        isModal = true,
-//        skipSlightlyExpanded = true,
-//    )
-    val bottomSheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true,
-        // confirmValueChange = { it != SheetValue.Hidden },
-    )
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(
         onDismissRequest = {
@@ -88,6 +78,7 @@ fun FestivalSearchBottomSheet(
         contentWindowInsets = { WindowInsets(top = 0) },
         modifier = Modifier
             .fillMaxHeight()
+            .statusBarsPadding()
             .padding(top = 18.dp),
     ) {
         Column(

--- a/feature/liked-booth/src/main/kotlin/com/unifest/android/feature/liked_booth/LikedBoothScreen.kt
+++ b/feature/liked-booth/src/main/kotlin/com/unifest/android/feature/liked_booth/LikedBoothScreen.kt
@@ -107,8 +107,8 @@ internal fun LikedBoothScreen(
                             .clickable {
                                 onAction(LikedBoothUiAction.OnLikedBoothItemClick(booth.id))
                             }
-                            .animateItemPlacement(
-                                animationSpec = tween(
+                            .animateItem(
+                                placementSpec = tween(
                                     durationMillis = 500,
                                     easing = LinearOutSlowInEasing,
                                 ),

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
@@ -106,32 +106,17 @@ internal fun StampBoothBottomSheet(
                     modifier = Modifier.padding(horizontal = 30.dp),
                 ) {
                     Spacer(modifier = Modifier.height(24.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = schoolName,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                style = Content1,
-                            )
-                            Spacer(modifier = Modifier.height(6.dp))
-                            Text(
-                                text = stringResource(id = R.string.stamp_booth),
-                                color = MaterialTheme.colorScheme.onBackground,
-                                style = Title1,
-                            )
-                        }
-                        Icon(
-                            painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
-                            contentDescription = "닫기",
-                            modifier = Modifier.clickable {
-                                onAction(StampUiAction.OnDismiss)
-                            },
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
+                    Text(
+                        text = schoolName,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = Content1,
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(id = R.string.stamp_booth),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = Title1,
+                    )
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
                         text = "총 ${stampBoothList.size}개",

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -19,10 +18,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -30,7 +27,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
@@ -51,10 +47,7 @@ internal fun StampBoothBottomSheet(
     stampBoothList: ImmutableList<StampBoothModel>,
     onAction: (StampUiAction) -> Unit,
 ) {
-    val bottomSheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true,
-        confirmValueChange = { it != SheetValue.Hidden },
-    )
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val interactionSource = remember { MutableInteractionSource() }
 
     ModalBottomSheet(

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothBottomSheet.kt
@@ -2,7 +2,9 @@ package com.unifest.android.feature.stamp.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -11,27 +13,31 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.Content1
+import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Title1
 import com.unifest.android.core.designsystem.theme.UnifestTheme
-import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.model.StampBoothModel
 import com.unifest.android.feature.stamp.R
 import com.unifest.android.feature.stamp.viewmodel.stamp.StampUiAction
@@ -49,20 +55,27 @@ internal fun StampBoothBottomSheet(
         skipPartiallyExpanded = true,
         confirmValueChange = { it != SheetValue.Hidden },
     )
+    val interactionSource = remember { MutableInteractionSource() }
 
     ModalBottomSheet(
         onDismissRequest = {
             onAction(StampUiAction.OnDismiss)
         },
         sheetState = bottomSheetState,
-        shape = RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp),
+        sheetGesturesEnabled = false,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         containerColor = MaterialTheme.colorScheme.surface,
         dragHandle = {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.surface)
-                    .padding(top = 10.dp),
+                    .padding(vertical = 12.dp)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = {},
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 HorizontalDivider(
@@ -77,8 +90,10 @@ internal fun StampBoothBottomSheet(
         contentWindowInsets = { WindowInsets(top = 0) },
         modifier = Modifier
             .fillMaxHeight()
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(top = 18.dp),
+            .statusBarsPadding()
+            .padding(top = 18.dp)
+            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         LazyColumn(
             modifier = Modifier
@@ -91,17 +106,32 @@ internal fun StampBoothBottomSheet(
                     modifier = Modifier.padding(horizontal = 30.dp),
                 ) {
                     Spacer(modifier = Modifier.height(24.dp))
-                    Text(
-                        text = schoolName,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        style = Content1,
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Text(
-                        text = stringResource(id = R.string.stamp_booth),
-                        color = MaterialTheme.colorScheme.onBackground,
-                        style = Title1,
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = schoolName,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                style = Content1,
+                            )
+                            Spacer(modifier = Modifier.height(6.dp))
+                            Text(
+                                text = stringResource(id = R.string.stamp_booth),
+                                color = MaterialTheme.colorScheme.onBackground,
+                                style = Title1,
+                            )
+                        }
+                        Icon(
+                            painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
+                            contentDescription = "닫기",
+                            modifier = Modifier.clickable {
+                                onAction(StampUiAction.OnDismiss)
+                            },
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
                         text = "총 ${stampBoothList.size}개",

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothItem.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/component/StampBoothItem.kt
@@ -39,7 +39,7 @@ internal fun StampBoothItem(
 ) {
     Column(
         modifier = modifier
-            .background(MaterialTheme.colorScheme.background)
+            .background(MaterialTheme.colorScheme.surface)
             .padding(horizontal = 20.dp),
     ) {
         Spacer(modifier = Modifier.height(16.dp))

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampUiState.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampUiState.kt
@@ -10,7 +10,6 @@ data class StampUiState(
     val stampEnabledFestivalList: ImmutableList<StampFestivalModel> = persistentListOf(),
     val selectedFestival: StampFestivalModel = StampFestivalModel(0, "", "", ""),
     val collectedStampCount: Int = 0,
-    val enabledStampCount: Int = 0,
     val stampBoothList: ImmutableList<StampBoothModel> = persistentListOf(),
     val isStampBoothDialogVisible: Boolean = false,
     val isPermissionDialogVisible: Boolean = false,

--- a/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
+++ b/feature/stamp/src/main/kotlin/com/unifest/android/feature/stamp/viewmodel/stamp/StampViewModel.kt
@@ -93,7 +93,6 @@ class StampViewModel @Inject constructor(
                 .onSuccess { stampEnabledBoothList ->
                     _uiState.update {
                         it.copy(
-                            enabledStampCount = stampEnabledBoothList.size,
                             stampBoothList = stampEnabledBoothList.toImmutableList(),
                         )
                     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ androidx-datastore = "1.1.4"
 androidx-room = "2.7.1"
 androidx-activity-compose = "1.10.1"
 androidx-compose = "1.7.4"
-androidx-compose-material3 = "1.3.2"
+androidx-compose-material3 = "1.4.0-alpha14"
 androidx-hilt-navigation-compose = "1.2.0"
 androidx-test-core = "1.6.1"
 
@@ -100,7 +100,6 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
-androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidx-compose-material3" }
 androidx-compose-material3-windowSizeClass = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
@@ -200,7 +199,6 @@ baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprof
 androidx-compose = [
     "androidx-compose-foundation",
     "androidx-compose-foundation-layout",
-    "androidx-compose-material-iconsExtended",
     "androidx-compose-material3",
     "androidx-compose-material3-windowSizeClass",
     "androidx-compose-runtime",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "40"
-versionName = "1.4.1"
+versionCode = "41"
+versionName = "1.4.2"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 플러스(+) 및 마이너스(-) 커스텀 아이콘이 추가되었습니다.

- **버그 수정**
    - 일부 컴포넌트의 아이템 애니메이션 처리가 개선되었습니다.
    - 특정 하단 시트가 시스템 상태바와 겹치지 않도록 패딩이 추가되었습니다.

- **스타일**
    - 하단 시트의 모서리 라운드 및 드래그 핸들 스타일이 개선되었습니다.
    - 일부 컴포넌트의 배경 색상이 조정되었습니다.

- **기타**
    - 불필요한 아이콘 라이브러리가 제거되고, Compose Material3 라이브러리 버전이 업데이트되었습니다.
    - 스탬프 관련 UI 상태에서 사용하지 않는 속성이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->