### PR TITLE
[fix] 부스 운영 종료 시각이 자정이 넘어가는 경우, 운영 종료라고 표기되는 문제 해결

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "41"
-versionName = "1.4.2"
+versionCode = "42"
+versionName = "1.4.3"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.8.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 자정 이후까지 운영되는 부스의 운영 상태가 올바르게 표시되도록 개선되었습니다.

- **기타**
  - 앱 버전이 1.4.2에서 1.4.3으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->