### PR TITLE
[refactor] MenuStatus Enum 으로 리팩토링

### DIFF
--- a/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/BoothEntityMapper.kt
+++ b/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/BoothEntityMapper.kt
@@ -4,6 +4,7 @@ import com.unifest.android.core.database.entity.LikedBoothEntity
 import com.unifest.android.core.database.entity.MenuEntity
 import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.MenuStatus
 
 internal fun LikedBoothEntity.toModel(): BoothDetailModel {
     return BoothDetailModel(
@@ -26,7 +27,7 @@ internal fun MenuEntity.toModel(): MenuModel {
         name = name,
         price = price,
         imgUrl = imgUrl,
-        status = status,
+        status = MenuStatus.fromString(status),
     )
 }
 

--- a/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
+++ b/core/data/impl/src/main/kotlin/com/unifest/android/core/data/mapper/BoothMapper.kt
@@ -4,6 +4,7 @@ import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.BoothModel
 import com.unifest.android.core.model.LikedBoothModel
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.MenuStatus
 import com.unifest.android.core.model.ScheduleModel
 import com.unifest.android.core.model.WaitingModel
 import com.unifest.android.core.network.response.booth.Booth
@@ -46,7 +47,7 @@ internal fun Menu.toModel(): MenuModel {
         name = name,
         price = price,
         imgUrl = imgUrl ?: "",
-        status = status ?: "",
+        status = MenuStatus.fromString(status),
     )
 }
 

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/BoothDetailModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/BoothDetailModel.kt
@@ -58,7 +58,8 @@ enum class MenuStatus(val value: String) {
     UNDER_50("UNDER_50"),
     UNDER_10("UNDER_10"),
     SOLD_OUT("SOLD_OUT"),
-    NO_DATA("NO_DATA");
+    NO_DATA("NO_DATA"),
+    ;
 
     companion object {
         fun fromString(value: String?): MenuStatus {

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/BoothDetailModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/BoothDetailModel.kt
@@ -27,7 +27,7 @@ data class MenuModel(
     val name: String,
     val price: Int,
     val imgUrl: String,
-    val status: String,
+    val status: MenuStatus,
 )
 
 @Stable
@@ -51,3 +51,18 @@ data class ScheduleModel(
     val openTime: String,
     val closeTime: String,
 )
+
+@Stable
+enum class MenuStatus(val value: String) {
+    ENOUGH("ENOUGH"),
+    UNDER_50("UNDER_50"),
+    UNDER_10("UNDER_10"),
+    SOLD_OUT("SOLD_OUT"),
+    NO_DATA("NO_DATA");
+
+    companion object {
+        fun fromString(value: String?): MenuStatus {
+            return value?.let { MenuStatus.entries.find { it.value == value } } ?: NO_DATA
+        }
+    }
+}

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/MenuImageDialog.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/MenuImageDialog.kt
@@ -28,6 +28,7 @@ import com.unifest.android.core.designsystem.theme.Content1
 import com.unifest.android.core.designsystem.theme.Title2
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.MenuStatus
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,7 +94,7 @@ private fun MenuImageDialogPreview() {
                 name = "모둠 사시미",
                 price = 45000,
                 imgUrl = "",
-                status = "10개 미만 남음",
+                status = MenuStatus.UNDER_10,
             ),
         )
     }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuItem.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuItem.kt
@@ -30,6 +30,7 @@ import com.unifest.android.core.designsystem.theme.MenuPrice
 import com.unifest.android.core.designsystem.theme.MenuTitle
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.MenuStatus
 import com.unifest.android.feature.booth.R
 import com.unifest.android.feature.booth.viewmodel.BoothUiAction
 
@@ -62,7 +63,7 @@ internal fun MenuItem(
                 modifier = Modifier.matchParentSize(),
             )
 
-            if (menu.status == "SOLD_OUT") {
+            if (menu.status == MenuStatus.SOLD_OUT) {
                 Box(
                     modifier = Modifier
                         .matchParentSize()
@@ -83,7 +84,7 @@ internal fun MenuItem(
         ) {
             Text(
                 text = menu.name,
-                color = if (menu.status == "SOLD_OUT") {
+                color = if (menu.status == MenuStatus.SOLD_OUT) {
                     MaterialTheme.colorScheme.secondaryContainer
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant
@@ -93,7 +94,7 @@ internal fun MenuItem(
             Spacer(modifier = Modifier.height(3.dp))
             Text(
                 text = menu.price.formatAsCurrency(),
-                color = if (menu.status == "SOLD_OUT") {
+                color = if (menu.status == MenuStatus.SOLD_OUT) {
                     MaterialTheme.colorScheme.surfaceVariant
                 } else {
                     MaterialTheme.colorScheme.onBackground
@@ -116,7 +117,7 @@ private fun MenuItemPreview() {
                 name = "닭강정",
                 price = 6000,
                 imgUrl = "",
-                status = "ENOUGH",
+                status = MenuStatus.ENOUGH,
             ),
             onAction = {},
         )
@@ -133,7 +134,7 @@ private fun MenuItemSoldOutPreview() {
                 name = "닭강정",
                 price = 6000,
                 imgUrl = "",
-                status = "SOLD_OUT",
+                status = MenuStatus.SOLD_OUT,
             ),
             onAction = {},
         )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuStatusTag.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuStatusTag.kt
@@ -77,7 +77,7 @@ internal fun Tag(
                 )
             }
 
-            MenuStatus.NO_DATA  -> {
+            MenuStatus.NO_DATA -> {
                 Text(
                     text = stringResource(id = R.string.no_menu_status),
                     style = Content7,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuStatusTag.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/MenuStatusTag.kt
@@ -1,13 +1,12 @@
 package com.unifest.android.feature.booth.component
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import com.unifest.android.core.designsystem.ComponentPreview
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -15,15 +14,17 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.BottomMenuBar
 import com.unifest.android.core.designsystem.theme.Content7
 import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.MenuStatus
 import com.unifest.android.feature.booth.R
 
 @Composable
 internal fun Tag(
     modifier: Modifier = Modifier,
-    menuStatus: String = "",
+    menuStatus: MenuStatus,
 ) {
     Box(
         modifier = modifier
@@ -32,7 +33,7 @@ internal fun Tag(
             .padding(horizontal = 12.dp, vertical = 4.dp),
     ) {
         when (menuStatus) {
-            "SOLD_OUT" -> {
+            MenuStatus.SOLD_OUT -> {
                 Text(
                     text = stringResource(R.string.sold_out),
                     style = Content7,
@@ -40,7 +41,7 @@ internal fun Tag(
                 )
             }
 
-            "UNDER_10" -> {
+            MenuStatus.UNDER_10 -> {
                 val parts = "10개 미만 남음".split("남음")
                 Text(
                     buildAnnotatedString {
@@ -54,7 +55,7 @@ internal fun Tag(
                 )
             }
 
-            "UNDER_50" -> {
+            MenuStatus.UNDER_50 -> {
                 val parts = "50개 미만 남음".split("남음")
                 Text(
                     buildAnnotatedString {
@@ -68,7 +69,7 @@ internal fun Tag(
                 )
             }
 
-            "ENOUGH" -> {
+            MenuStatus.ENOUGH -> {
                 Text(
                     text = stringResource(R.string.enough_status),
                     style = Content7,
@@ -76,7 +77,7 @@ internal fun Tag(
                 )
             }
 
-            else -> {
+            MenuStatus.NO_DATA  -> {
                 Text(
                     text = stringResource(id = R.string.no_menu_status),
                     style = Content7,
@@ -91,6 +92,6 @@ internal fun Tag(
 @Composable
 private fun TagPreview() {
     UnifestTheme {
-        Tag(menuStatus = "10개 미만 남음")
+        Tag(menuStatus = MenuStatus.UNDER_10)
     }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothDetailPreviewParameterProvider.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothDetailPreviewParameterProvider.kt
@@ -3,6 +3,7 @@ package com.unifest.android.feature.booth.preview
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.unifest.android.core.model.BoothDetailModel
 import com.unifest.android.core.model.MenuModel
+import com.unifest.android.core.model.MenuStatus
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
 
 internal class BoothDetailPreviewParameterProvider : PreviewParameterProvider<BoothUiState> {
@@ -18,10 +19,10 @@ internal class BoothDetailPreviewParameterProvider : PreviewParameterProvider<Bo
                 latitude = 37.54224856023523f,
                 longitude = 127.07605430700158f,
                 menus = listOf(
-                    MenuModel(1L, "모둠 사시미", 45000, "", "10개 미만 남음"),
-                    MenuModel(2L, "모둠 사시미", 45000, "", "품절"),
-                    MenuModel(3L, "모둠 사시미", 45000, "", "50개 미만 남음"),
-                    MenuModel(4L, "모둠 사시미", 45000, "", "품절임막 5개 미만 남음"),
+                    MenuModel(1L, "모둠 사시미", 45000, "", MenuStatus.ENOUGH),
+                    MenuModel(2L, "모둠 사시미", 45000, "", MenuStatus.UNDER_10),
+                    MenuModel(3L, "모둠 사시미", 45000, "", MenuStatus.UNDER_50),
+                    MenuModel(4L, "모둠 사시미", 45000, "", MenuStatus.SOLD_OUT),
                 ),
             ),
         ),


### PR DESCRIPTION
- Refacor
  - 메뉴 재고 관련 status 를 `String` 대신 `Enum` 으로 변환했습니다.
  - `Response`에서는 `String` 으로 취급하며, `toModel()` 함수에서 String -> Enum 으로 변환합니다.
```kotlin
internal fun Menu.toModel(): MenuModel {
    return MenuModel(
        // ...
        status = MenuStatus.fromString(status)
    )
}
```

<img width="347" height="649" alt="image" src="https://github.com/user-attachments/assets/93265bb5-fe12-473d-a218-7a878420a7a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메뉴 상태를 문자열 대신 MenuStatus 열거형(enum)으로 표시하여 일관성과 타입 안정성이 향상되었습니다.

* **Refactor**
  * 메뉴 상태 관련 UI 및 데이터 처리 로직이 MenuStatus enum을 사용하도록 전면 수정되었습니다.
  * 프리뷰 및 컴포넌트에서 메뉴 상태 전달 방식이 문자열에서 enum으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->