### PR TITLE
[refactor] 뷰모델 공유 로직 수정

### DIFF
--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailLocationScreen.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailLocationScreen.kt
@@ -49,7 +49,7 @@ import com.unifest.android.feature.booth_detail.preview.BoothDetailPreviewParame
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiAction
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiEvent
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiState
-import com.unifest.android.feature.booth_detail.viewmodel.BoothViewModel
+import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 val permissionsToRequest = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION)
@@ -57,7 +57,7 @@ val permissionsToRequest = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION, M
 @Composable
 internal fun BoothDetailLocationRoute(
     popBackStack: () -> Unit,
-    viewModel: BoothViewModel = hiltViewModel(),
+    viewModel: BoothDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val activity = LocalActivity.current

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
@@ -74,7 +74,7 @@ import com.unifest.android.feature.booth_detail.preview.BoothDetailPreviewParame
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiAction
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiEvent
 import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailUiState
-import com.unifest.android.feature.booth_detail.viewmodel.BoothViewModel
+import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailViewModel
 import com.unifest.android.feature.booth_detail.viewmodel.ErrorType
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
@@ -91,7 +91,7 @@ internal fun BoothDetailRoute(
     popBackStack: () -> Unit,
     navigateToBoothDetailLocation: () -> Unit,
     navigateToWaiting: () -> Unit,
-    viewModel: BoothViewModel = hiltViewModel(),
+    viewModel: BoothDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val systemUiController = rememberExSystemUiController()

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
@@ -1,16 +1,16 @@
 package com.unifest.android.feature.booth_detail.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
-import com.unifest.android.core.common.extension.sharedViewModel
 import com.unifest.android.core.navigation.Route
 import com.unifest.android.feature.booth_detail.BoothDetailRoute
 import com.unifest.android.feature.booth_detail.BoothDetailLocationRoute
-import com.unifest.android.feature.booth_detail.viewmodel.BoothViewModel
+import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailViewModel
 
 fun NavController.navigateToBoothDetail(
     boothId: Long,
@@ -24,29 +24,27 @@ fun NavController.navigateToBoothDetailLocation() {
 
 fun NavGraphBuilder.boothDetailNavGraph(
     padding: PaddingValues,
-    navController: NavHostController,
     popBackStack: () -> Unit,
     navigateToBoothDetailLocation: () -> Unit,
     navigateToWaiting: () -> Unit,
+    getBackStackViewModel: @Composable (NavBackStackEntry) -> BoothDetailViewModel
 ) {
     navigation<Route.BoothDetail>(
         startDestination = Route.BoothDetail.BoothDetail::class,
     ) {
         composable<Route.BoothDetail.BoothDetail> { navBackStackEntry ->
-            val viewModel = navBackStackEntry.sharedViewModel<BoothViewModel>(navController)
             BoothDetailRoute(
                 padding = padding,
                 popBackStack = popBackStack,
                 navigateToBoothDetailLocation = navigateToBoothDetailLocation,
                 navigateToWaiting = navigateToWaiting,
-                viewModel = viewModel,
+                viewModel = getBackStackViewModel(navBackStackEntry),
             )
         }
         composable<Route.BoothDetail.BoothLocation> { navBackStackEntry ->
-            val viewModel = navBackStackEntry.sharedViewModel<BoothViewModel>(navController)
             BoothDetailLocationRoute(
                 popBackStack = popBackStack,
-                viewModel = viewModel,
+                viewModel = getBackStackViewModel(navBackStackEntry),
             )
         }
     }

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
@@ -27,7 +27,7 @@ fun NavGraphBuilder.boothDetailNavGraph(
     popBackStack: () -> Unit,
     navigateToBoothDetailLocation: () -> Unit,
     navigateToWaiting: () -> Unit,
-    getBackStackViewModel: @Composable (NavBackStackEntry) -> BoothDetailViewModel
+    getBackStackViewModel: @Composable (NavBackStackEntry) -> BoothDetailViewModel,
 ) {
     navigation<Route.BoothDetail>(
         startDestination = Route.BoothDetail.BoothDetail::class,

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 import com.unifest.android.core.designsystem.R as designR
 
 @HiltViewModel
-class BoothViewModel @Inject constructor(
+class BoothDetailViewModel @Inject constructor(
     private val boothRepository: BoothRepository,
     private val likedBoothRepository: LikedBoothRepository,
     private val waitingRepository: WaitingRepository,
@@ -109,7 +109,7 @@ class BoothViewModel @Inject constructor(
                     }
                 }
                 .onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
         }
     }
@@ -127,7 +127,7 @@ class BoothViewModel @Inject constructor(
                     getBoothLikes()
                 }
                 .onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
             _uiState.update {
                 it.copy(isLoading = false)
@@ -148,7 +148,7 @@ class BoothViewModel @Inject constructor(
                     }
                 }
                 .onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
         }
     }
@@ -163,7 +163,7 @@ class BoothViewModel @Inject constructor(
                     checkLikedBooth()
                 }
                 .onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
         }
     }
@@ -263,7 +263,7 @@ class BoothViewModel @Inject constructor(
                     setWaitingDialogVisible(false)
                     setConfirmDialogVisible(true)
                 }.onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
             }
         } else {
@@ -325,7 +325,7 @@ class BoothViewModel @Inject constructor(
                     }
                 }
                 .onFailure { exception ->
-                    handleException(exception, this@BoothViewModel)
+                    handleException(exception, this@BoothDetailViewModel)
                 }
         }
     }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.util.Consumer
 import androidx.navigation.compose.NavHost
 import com.unifest.android.core.common.UiText
+import com.unifest.android.core.common.extension.sharedViewModel
 import com.unifest.android.core.designsystem.component.UnifestScaffold
 import com.unifest.android.core.designsystem.component.UnifestSnackBar
 import com.unifest.android.feature.booth.navigation.boothNavGraph
 import com.unifest.android.feature.booth_detail.navigation.boothDetailNavGraph
+import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailViewModel
 import com.unifest.android.feature.home.navigation.homeNavGraph
 import com.unifest.android.feature.liked_booth.navigation.likedBoothNavGraph
 import com.unifest.android.feature.main.component.MainBottomBar
@@ -99,10 +101,14 @@ internal fun MainScreen(
             )
             boothDetailNavGraph(
                 padding = innerPadding,
-                navController = navigator.navController,
                 popBackStack = navigator::popBackStackIfNotMap,
                 navigateToBoothDetailLocation = navigator::navigateToBoothDetailLocation,
                 navigateToWaiting = navigator::navigateToWaiting,
+                getBackStackViewModel = { navBackStackEntry ->
+                    navBackStackEntry.sharedViewModel<BoothDetailViewModel>(
+                        navController = navigator.navController,
+                    )
+                },
             )
             waitingNavGraph(
                 padding = innerPadding,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 부스 상세 화면에서 사용되는 ViewModel 명칭이 BoothViewModel에서 BoothDetailViewModel로 변경되었습니다.
  * 네비게이션 그래프에서 ViewModel 전달 방식이 개선되어, ViewModel을 보다 명확하고 유연하게 사용할 수 있게 되었습니다.
  * 내부적으로 ViewModel 관리 및 전달 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->