### PR TITLE
[feat] 부스 탭 UI 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable-night/ic_check_waiting.xml
+++ b/core/designsystem/src/main/res/drawable-night/ic_check_waiting.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M5,0L14,0A5,5 0,0 1,19 5L19,14A5,5 0,0 1,14 19L5,19A5,5 0,0 1,0 14L0,5A5,5 0,0 1,5 0z"
+      android:fillColor="#FF748A"/>
+  <path
+      android:pathData="M14.112,5.274C14.472,4.904 15.066,4.904 15.425,5.275C15.77,5.63 15.77,6.194 15.425,6.549L8.703,13.478C8.212,13.984 7.4,13.984 6.909,13.478L4.404,10.896C4.058,10.539 4.058,9.971 4.406,9.616C4.767,9.246 5.362,9.248 5.721,9.619L7.268,11.212C7.563,11.516 8.05,11.516 8.344,11.212L14.112,5.274Z"
+      android:strokeWidth="0.5"
+      android:fillColor="#131316"
+      android:strokeColor="#131316"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable-night/ic_check_waiting_unchecked.xml
+++ b/core/designsystem/src/main/res/drawable-night/ic_check_waiting_unchecked.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M5,0.5L14,0.5A4.5,4.5 0,0 1,18.5 5L18.5,14A4.5,4.5 0,0 1,14 18.5L5,18.5A4.5,4.5 0,0 1,0.5 14L0.5,5A4.5,4.5 0,0 1,5 0.5z"
+      android:fillColor="#00000000"
+      android:strokeColor="#343438"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_check_waiting.xml
+++ b/core/designsystem/src/main/res/drawable/ic_check_waiting.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M5,0L14,0A5,5 0,0 1,19 5L19,14A5,5 0,0 1,14 19L5,19A5,5 0,0 1,0 14L0,5A5,5 0,0 1,5 0z"
+      android:fillColor="#FF748A"/>
+  <path
+      android:pathData="M14.112,5.274C14.472,4.904 15.066,4.904 15.425,5.275C15.77,5.63 15.77,6.194 15.425,6.549L8.703,13.478C8.212,13.984 7.4,13.984 6.909,13.478L4.404,10.896C4.058,10.539 4.058,9.971 4.406,9.616C4.767,9.246 5.362,9.248 5.721,9.619L7.268,11.212C7.563,11.516 8.05,11.516 8.344,11.212L14.112,5.274Z"
+      android:strokeWidth="0.5"
+      android:fillColor="#ffffff"
+      android:strokeColor="#ffffff"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_check_waiting_unchecked.xml
+++ b/core/designsystem/src/main/res/drawable/ic_check_waiting_unchecked.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M5,0.5L14,0.5A4.5,4.5 0,0 1,18.5 5L18.5,14A4.5,4.5 0,0 1,14 18.5L5,18.5A4.5,4.5 0,0 1,0.5 14L0.5,5A4.5,4.5 0,0 1,5 0.5z"
+      android:fillColor="#00000000"
+      android:strokeColor="#D4D6DC"/>
+</vector>

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/BoothTabModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/BoothTabModel.kt
@@ -1,0 +1,13 @@
+package com.unifest.android.core.model
+
+import androidx.compose.runtime.Stable
+
+@Stable
+data class BoothTabModel(
+    val id: Long = 0L,
+    val name: String = "",
+    val description: String = "",
+    val thumbnail: String = "",
+    val location: String = "",
+    val waitingEnabled: Boolean = false,
+)

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -1,13 +1,23 @@
 package com.unifest.android.feature.booth
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.unifest.android.core.common.ObserveAsEvents
+import com.unifest.android.core.designsystem.component.NetworkErrorDialog
+import com.unifest.android.core.designsystem.component.ServerErrorDialog
+import com.unifest.android.feature.booth.viewmodel.BoothUiAction
 import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
+import com.unifest.android.feature.booth.viewmodel.BoothUiState
 import com.unifest.android.feature.booth.viewmodel.BoothViewModel
+import com.unifest.android.feature.booth.viewmodel.ErrorType
 
 @Composable
 internal fun BoothRoute(
@@ -15,6 +25,46 @@ internal fun BoothRoute(
     navigateToBoothDetail: (Long) -> Unit,
     viewModel: BoothViewModel = hiltViewModel(),
 ) {
-    padding
-    navigateToBoothDetail
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    ObserveAsEvents(flow = viewModel.uiEvent) { event ->
+        when (event) {
+            is BoothUiEvent.NavigateToBoothDetail -> navigateToBoothDetail(event.boothId)
+        }
+    }
+
+    BoothContent(
+        padding = padding,
+        uiState = uiState,
+        onAction = viewModel::onAction,
+    )
+
+}
+
+@Composable
+internal fun BoothContent(
+    padding: PaddingValues,
+    uiState: BoothUiState,
+    onAction: (BoothUiAction) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding),
+    ) {
+        Column {  }
+
+
+        if (uiState.isServerErrorDialogVisible) {
+            ServerErrorDialog(
+                onRetryClick = { onAction(BoothUiAction.OnRetryClick(ErrorType.SERVER)) },
+            )
+        }
+
+        if (uiState.isNetworkErrorDialogVisible) {
+            NetworkErrorDialog(
+                onRetryClick = { onAction(BoothUiAction.OnRetryClick(ErrorType.NETWORK)) },
+            )
+        }
+    }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -62,7 +62,6 @@ internal fun BoothRoute(
         uiState = uiState,
         onAction = viewModel::onAction,
     )
-
 }
 
 @Composable
@@ -153,7 +152,7 @@ internal fun BoothContent(
             }
         }
         items(
-            items = uiState.boothList,
+            items = uiState.showingBoothList,
             key = { booth -> booth.id },
         ) { booth ->
             BoothItem(
@@ -182,4 +181,3 @@ private fun StampScreenPreview(
         )
     }
 }
-

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -2,14 +2,19 @@ package com.unifest.android.feature.booth
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.unifest.android.core.common.ObserveAsEvents
+import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
+import com.unifest.android.feature.booth.viewmodel.BoothViewModel
 
 @Composable
 internal fun BoothRoute(
     padding: PaddingValues,
-    popBackStack: () -> Unit,
     navigateToBoothDetail: (Long) -> Unit,
+    viewModel: BoothViewModel = hiltViewModel(),
 ) {
     padding
-    popBackStack
     navigateToBoothDetail
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -33,6 +34,7 @@ import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Content8
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.ui.DevicePreview
+import com.unifest.android.feature.booth.component.BoothItem
 import com.unifest.android.feature.booth.preview.BoothPreviewParameterProvider
 import com.unifest.android.feature.booth.viewmodel.BoothUiAction
 import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
@@ -149,6 +151,19 @@ internal fun BoothContent(
                     )
                 }
             }
+        }
+        items(
+            items = uiState.boothList,
+            key = { booth -> booth.id },
+        ) { booth ->
+            BoothItem(
+                booth = booth,
+                modifier = Modifier
+                    .padding(vertical = 1.dp)
+                    .clickable {
+                        onAction(BoothUiAction.OnBoothItemClick(booth.id))
+                    },
+            )
         }
     }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -3,16 +3,32 @@ package com.unifest.android.feature.booth
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
 import com.unifest.android.core.designsystem.component.ServerErrorDialog
+import com.unifest.android.core.designsystem.theme.BoothTitle2
+import com.unifest.android.core.designsystem.theme.Content8
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.ui.DevicePreview
+import com.unifest.android.feature.booth.preview.BoothPreviewParameterProvider
 import com.unifest.android.feature.booth.viewmodel.BoothUiAction
 import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
@@ -52,7 +68,7 @@ internal fun BoothContent(
             .fillMaxSize()
             .padding(padding),
     ) {
-        Column {  }
+        Column { }
 
 
         if (uiState.isServerErrorDialogVisible) {
@@ -68,3 +84,19 @@ internal fun BoothContent(
         }
     }
 }
+
+@DevicePreview
+@Composable
+private fun StampScreenPreview(
+    @PreviewParameter(BoothPreviewParameterProvider::class)
+    boothUiState: BoothUiState,
+) {
+    UnifestTheme {
+        BoothContent(
+            padding = PaddingValues(),
+            uiState = boothUiState,
+            onAction = {},
+        )
+    }
+}
+

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -1,22 +1,25 @@
 package com.unifest.android.feature.booth
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -25,6 +28,8 @@ import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
 import com.unifest.android.core.designsystem.component.ServerErrorDialog
 import com.unifest.android.core.designsystem.theme.BoothTitle2
+import com.unifest.android.core.designsystem.theme.Content1
+import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Content8
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.ui.DevicePreview
@@ -34,6 +39,7 @@ import com.unifest.android.feature.booth.viewmodel.BoothUiEvent
 import com.unifest.android.feature.booth.viewmodel.BoothUiState
 import com.unifest.android.feature.booth.viewmodel.BoothViewModel
 import com.unifest.android.feature.booth.viewmodel.ErrorType
+import com.unifest.android.core.designsystem.R as designR
 
 @Composable
 internal fun BoothRoute(
@@ -49,7 +55,7 @@ internal fun BoothRoute(
         }
     }
 
-    BoothContent(
+    BoothScreen(
         padding = padding,
         uiState = uiState,
         onAction = viewModel::onAction,
@@ -58,7 +64,7 @@ internal fun BoothRoute(
 }
 
 @Composable
-internal fun BoothContent(
+internal fun BoothScreen(
     padding: PaddingValues,
     uiState: BoothUiState,
     onAction: (BoothUiAction) -> Unit,
@@ -66,10 +72,14 @@ internal fun BoothContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
             .padding(padding),
     ) {
-        Column { }
-
+        BoothContent(
+            uiState = uiState,
+            onAction = onAction,
+            modifier = Modifier.padding(horizontal = 20.dp),
+        )
 
         if (uiState.isServerErrorDialogVisible) {
             ServerErrorDialog(
@@ -85,6 +95,64 @@ internal fun BoothContent(
     }
 }
 
+@Composable
+internal fun BoothContent(
+    uiState: BoothUiState,
+    onAction: (BoothUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.padding(top = 18.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        item {
+            Text(
+                text = uiState.campusName,
+                color = MaterialTheme.colorScheme.onBackground,
+                style = Content8,
+            )
+        }
+        item {
+            Text(
+                text = stringResource(R.string.booth_list),
+                color = MaterialTheme.colorScheme.onBackground,
+                style = BoothTitle2,
+            )
+        }
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.total_booth_count, uiState.totalBoothCount),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = Content2,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(
+                            id = if (uiState.waitingAvailabilityChecked) designR.drawable.ic_check_waiting else designR.drawable.ic_check_waiting_unchecked,
+                        ),
+                        contentDescription = "check box icon",
+                        tint = Color.Unspecified,
+                        modifier = Modifier.clickable {
+                            onAction(BoothUiAction.OnWaitingCheckBoxClick)
+                        },
+                    )
+                    Text(
+                        text = stringResource(id = R.string.waiting_availability),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = Content1,
+                    )
+                }
+            }
+        }
+    }
+}
+
 @DevicePreview
 @Composable
 private fun StampScreenPreview(
@@ -92,7 +160,7 @@ private fun StampScreenPreview(
     boothUiState: BoothUiState,
 ) {
     UnifestTheme {
-        BoothContent(
+        BoothScreen(
             padding = PaddingValues(),
             uiState = boothUiState,
             onAction = {},

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
@@ -1,0 +1,115 @@
+package com.unifest.android.feature.booth.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.component.NetworkImage
+import com.unifest.android.core.designsystem.theme.Content2
+import com.unifest.android.core.designsystem.theme.Title2
+import com.unifest.android.core.designsystem.theme.Title5
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.BoothTabModel
+import com.unifest.android.core.designsystem.R as designR
+
+@Composable
+internal fun BoothItem(
+    booth: BoothTabModel,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+    ) {
+        Row {
+            NetworkImage(
+                imgUrl = booth.thumbnail,
+                contentDescription = "Stamp Booth Thumbnail",
+                modifier = Modifier
+                    .size(86.dp)
+                    .clip(RoundedCornerShape(16.dp)),
+                placeholder = painterResource(id = designR.drawable.item_placeholder),
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) {
+                Text(
+                    text = booth.name,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = Title2,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = booth.description,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = Content2,
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Row {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = designR.drawable.ic_location_green),
+                        contentDescription = "Location Icon",
+                        tint = Color.Unspecified,
+                    )
+                    Spacer(modifier = Modifier.width(3.dp))
+                    Text(
+                        text = booth.location,
+                        modifier = Modifier.align(Alignment.CenterVertically),
+                        color = MaterialTheme.colorScheme.onSecondary,
+                        style = Title5,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun StampBoothItemPreview() {
+    UnifestTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(20.dp),
+        ) {
+            BoothItem(
+                booth = BoothTabModel(
+                    id = 1,
+                    name = "컴공 주점",
+                    description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                    location = "학생회관 앞",
+                    waitingEnabled = true,
+                    thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+                ),
+            )
+        }
+    }
+}

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
@@ -38,7 +38,7 @@ internal fun BoothItem(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
+        modifier = modifier,
     ) {
         Row {
             NetworkImage(

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/component/BoothItem.kt
@@ -43,7 +43,7 @@ internal fun BoothItem(
         Row {
             NetworkImage(
                 imgUrl = booth.thumbnail,
-                contentDescription = "Stamp Booth Thumbnail",
+                contentDescription = "${booth.name} ${booth.description}",
                 modifier = Modifier
                     .size(86.dp)
                     .clip(RoundedCornerShape(16.dp)),

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
@@ -20,7 +20,6 @@ fun NavGraphBuilder.boothNavGraph(
     composable<MainTabRoute.Booth> {
         BoothRoute(
             padding = padding,
-            popBackStack = popBackStack,
             navigateToBoothDetail = navigateToBoothDetail,
         )
     }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/navigation/BoothNavigation.kt
@@ -14,7 +14,6 @@ fun NavController.navigateToBooth(navOptions: NavOptions) {
 
 fun NavGraphBuilder.boothNavGraph(
     padding: PaddingValues,
-    popBackStack: () -> Unit,
     navigateToBoothDetail: (Long) -> Unit,
 ) {
     composable<MainTabRoute.Booth> {

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothPreviewParameterProvider.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothPreviewParameterProvider.kt
@@ -11,7 +11,7 @@ internal class BoothPreviewParameterProvider : PreviewParameterProvider<BoothUiS
             campusName = "가천대학교 글로컬 캠퍼스",
             totalBoothCount = 3,
             waitingAvailabilityChecked = false,
-            stampEnabledBoothList = persistentListOf(
+            boothList = persistentListOf(
                 BoothTabModel(
                     id = 1,
                     name = "컴공 주점 부스",
@@ -21,7 +21,7 @@ internal class BoothPreviewParameterProvider : PreviewParameterProvider<BoothUiS
                     thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
                 ),
                 BoothTabModel(
-                    id = 1,
+                    id = 2,
                     name = "컴공 주점 부스",
                     location = "학생회관 앞",
                     description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
@@ -29,7 +29,7 @@ internal class BoothPreviewParameterProvider : PreviewParameterProvider<BoothUiS
                     thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
                 ),
                 BoothTabModel(
-                    id = 1,
+                    id = 3,
                     name = "컴공 주점 부스",
                     location = "학생회관 앞",
                     description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothPreviewParameterProvider.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/preview/BoothPreviewParameterProvider.kt
@@ -1,0 +1,44 @@
+package com.unifest.android.feature.booth.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.unifest.android.core.model.BoothTabModel
+import com.unifest.android.feature.booth.viewmodel.BoothUiState
+import kotlinx.collections.immutable.persistentListOf
+
+internal class BoothPreviewParameterProvider : PreviewParameterProvider<BoothUiState> {
+    override val values: Sequence<BoothUiState> = sequenceOf(
+        BoothUiState(
+            campusName = "가천대학교 글로컬 캠퍼스",
+            totalBoothCount = 3,
+            waitingAvailabilityChecked = false,
+            stampEnabledBoothList = persistentListOf(
+                BoothTabModel(
+                    id = 1,
+                    name = "컴공 주점 부스",
+                    location = "학생회관 앞",
+                    description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                    waitingEnabled = false,
+                    thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+                ),
+                BoothTabModel(
+                    id = 1,
+                    name = "컴공 주점 부스",
+                    location = "학생회관 앞",
+                    description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                    waitingEnabled = false,
+                    thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+                ),
+                BoothTabModel(
+                    id = 1,
+                    name = "컴공 주점 부스",
+                    location = "학생회관 앞",
+                    description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                    waitingEnabled = false,
+                    thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+                ),
+            ),
+            isServerErrorDialogVisible = false,
+            isNetworkErrorDialogVisible = false,
+        ),
+    )
+}

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
@@ -3,4 +3,10 @@ package com.unifest.android.feature.booth.viewmodel
 sealed interface BoothUiAction {
     data object OnWaitingCheckBoxClick : BoothUiAction
     data class OnBoothItemClick(val boothId: Long) : BoothUiAction
+    data class OnRetryClick(val error: ErrorType) : BoothUiAction
+}
+
+enum class ErrorType {
+    NETWORK,
+    SERVER,
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiAction.kt
@@ -1,0 +1,6 @@
+package com.unifest.android.feature.booth.viewmodel
+
+sealed interface BoothUiAction {
+    data object OnWaitingCheckBoxClick : BoothUiAction
+    data class OnBoothItemClick(val boothId: Long) : BoothUiAction
+}

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiEvent.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiEvent.kt
@@ -1,0 +1,5 @@
+package com.unifest.android.feature.booth.viewmodel
+
+sealed interface BoothUiEvent {
+    data class NavigateToBoothDetail(val boothId: Long) : BoothUiEvent
+}

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -1,0 +1,12 @@
+package com.unifest.android.feature.booth.viewmodel
+
+import com.unifest.android.core.model.BoothTabModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class BoothUiState(
+    val campusName: String = "",
+    val totalBoothCount: Int = 0,
+    val waitingAvailabilityChecked: Boolean = false,
+    val stampEnabledBoothList: ImmutableList<BoothTabModel> = persistentListOf(),
+)

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -7,7 +7,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class BoothUiState(
     val campusName: String = "",
     val totalBoothCount: Int = 0,
-    val waitingAvailabilityChecked: Boolean = true,
+    val waitingAvailabilityChecked: Boolean = false,
     val stampEnabledBoothList: ImmutableList<BoothTabModel> = persistentListOf(),
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -2,6 +2,7 @@ package com.unifest.android.feature.booth.viewmodel
 
 import com.unifest.android.core.model.BoothTabModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 data class BoothUiState(
@@ -9,6 +10,7 @@ data class BoothUiState(
     val totalBoothCount: Int = 0,
     val waitingAvailabilityChecked: Boolean = false,
     val boothList: ImmutableList<BoothTabModel> = persistentListOf(),
+    val showingBoothList: PersistentList<BoothTabModel> = persistentListOf(),
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
 )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -8,7 +8,7 @@ data class BoothUiState(
     val campusName: String = "",
     val totalBoothCount: Int = 0,
     val waitingAvailabilityChecked: Boolean = false,
-    val stampEnabledBoothList: ImmutableList<BoothTabModel> = persistentListOf(),
+    val boothList: ImmutableList<BoothTabModel> = persistentListOf(),
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
 )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothUiState.kt
@@ -7,6 +7,8 @@ import kotlinx.collections.immutable.persistentListOf
 data class BoothUiState(
     val campusName: String = "",
     val totalBoothCount: Int = 0,
-    val waitingAvailabilityChecked: Boolean = false,
+    val waitingAvailabilityChecked: Boolean = true,
     val stampEnabledBoothList: ImmutableList<BoothTabModel> = persistentListOf(),
+    val isServerErrorDialogVisible: Boolean = false,
+    val isNetworkErrorDialogVisible: Boolean = false,
 )

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -1,20 +1,34 @@
 package com.unifest.android.feature.booth.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
+import com.unifest.android.core.model.BoothTabModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
     private val _uiState: MutableStateFlow<BoothUiState> = MutableStateFlow(BoothUiState())
-    val uiState: StateFlow<BoothUiState> = _uiState.asStateFlow()
+    val uiState: StateFlow<BoothUiState> = _uiState
+        .onStart {
+            fetchBoothList()
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = BoothUiState(),
+        )
 
     private val _uiEvent = Channel<BoothUiEvent>()
     val uiEvent = _uiEvent.receiveAsFlow()
@@ -27,9 +41,103 @@ class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
         }
     }
 
-    private fun setWaitingAvailabilityChecked() {}
+    private fun setWaitingAvailabilityChecked() {
+        _uiState.update {
+            val newChecked = !it.waitingAvailabilityChecked
+            it.copy(
+                waitingAvailabilityChecked = newChecked,
+                showingBoothList = if (newChecked) {
+                    it.boothList.filter { booth -> booth.waitingEnabled }.toPersistentList()
+                } else {
+                    it.boothList.toPersistentList()
+                },
+            )
+        }
+    }
 
-    private fun navigateToBoothDetail(boothId: Long) {}
+    private fun fetchBoothList() {
+        val boothList = persistentListOf(
+            BoothTabModel(
+                id = 1,
+                name = "컴공 주점 부스1",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = false,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 2,
+                name = "컴공 주점 부스2",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = true,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 3,
+                name = "컴공 주점 부스3",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = false,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 4,
+                name = "컴공 주점 부스4",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = true,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 5,
+                name = "컴공 주점 부스5",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = true,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 6,
+                name = "컴공 주점 부스6",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = true,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 7,
+                name = "컴공 주점 부스7",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = true,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+            BoothTabModel(
+                id = 8,
+                name = "컴공 주점 부스8",
+                location = "학생회관 앞",
+                description = "저희 주점은 일본 이자카야를 모티브로 만든 컴공인을 위한 주점입니다",
+                waitingEnabled = false,
+                thumbnail = "https://cdn.pixabay.com/photo/2020/06/07/13/33/fireworks-5270439_1280.jpg",
+            ),
+        )
+
+        _uiState.update {
+            it.copy(
+                campusName = "가천대 글로컬 캠퍼스",
+                boothList = boothList,
+                totalBoothCount = boothList.size,
+                showingBoothList = boothList,
+            )
+        }
+    }
+
+    private fun navigateToBoothDetail(boothId: Long) {
+        viewModelScope.launch {
+            _uiEvent.send(BoothUiEvent.NavigateToBoothDetail(boothId))
+        }
+    }
 
     override fun setServerErrorDialogVisible(flag: Boolean) {
         _uiState.update {

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -23,6 +23,7 @@ class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
         when (action) {
             is BoothUiAction.OnBoothItemClick -> navigateToBoothDetail(action.boothId)
             is BoothUiAction.OnWaitingCheckBoxClick -> setWaitingAvailabilityChecked()
+            is BoothUiAction.OnRetryClick -> refresh(action.error)
         }
     }
 
@@ -39,6 +40,14 @@ class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
     override fun setNetworkErrorDialogVisible(flag: Boolean) {
         _uiState.update {
             it.copy(isNetworkErrorDialogVisible = flag)
+        }
+    }
+
+    private fun refresh(error: ErrorType) {
+        // TODO: API 호출 로직 추가
+        when (error) {
+            ErrorType.NETWORK -> setNetworkErrorDialogVisible(false)
+            ErrorType.SERVER -> setServerErrorDialogVisible(false)
         }
     }
 }

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -125,7 +125,7 @@ class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
 
         _uiState.update {
             it.copy(
-                campusName = "가천대 글로컬 캠퍼스",
+                campusName = "가천대 글로벌 캠퍼스",
                 boothList = boothList,
                 totalBoothCount = boothList.size,
                 showingBoothList = boothList,
@@ -152,7 +152,7 @@ class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
     }
 
     private fun refresh(error: ErrorType) {
-        // TODO: API 호출 로직 추가
+        fetchBoothList()
         when (error) {
             ErrorType.NETWORK -> setNetworkErrorDialogVisible(false)
             ErrorType.SERVER -> setServerErrorDialogVisible(false)

--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/viewmodel/BoothViewModel.kt
@@ -1,0 +1,44 @@
+package com.unifest.android.feature.booth.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.unifest.android.core.common.ErrorHandlerActions
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class BoothViewModel @Inject constructor() : ViewModel(), ErrorHandlerActions {
+    private val _uiState: MutableStateFlow<BoothUiState> = MutableStateFlow(BoothUiState())
+    val uiState: StateFlow<BoothUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = Channel<BoothUiEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    fun onAction(action: BoothUiAction) {
+        when (action) {
+            is BoothUiAction.OnBoothItemClick -> navigateToBoothDetail(action.boothId)
+            is BoothUiAction.OnWaitingCheckBoxClick -> setWaitingAvailabilityChecked()
+        }
+    }
+
+    private fun setWaitingAvailabilityChecked() {}
+
+    private fun navigateToBoothDetail(boothId: Long) {}
+
+    override fun setServerErrorDialogVisible(flag: Boolean) {
+        _uiState.update {
+            it.copy(isServerErrorDialogVisible = flag)
+        }
+    }
+
+    override fun setNetworkErrorDialogVisible(flag: Boolean) {
+        _uiState.update {
+            it.copy(isNetworkErrorDialogVisible = flag)
+        }
+    }
+}

--- a/feature/booth/src/main/res/values/strings.xml
+++ b/feature/booth/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-
+    <string name="booth_list">부스 목록</string>
+    <string name="total_booth_count">총 %d개</string>
+    <string name="waiting_availability">웨이팅 가능 여부</string>
 </resources>

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -135,7 +135,6 @@ internal fun MainScreen(
             )
             boothNavGraph(
                 padding = innerPadding,
-                popBackStack = navigator::popBackStackIfNotMap,
                 navigateToBoothDetail = navigator::navigateToBoothDetail,
             )
         }


### PR DESCRIPTION
- 부스 탭 UI 구현했습니다.
- 기존 스탬프 화면에서 사용하는 부스 UI 를 재사용했습니다.
최대한 기존 코드들과 비슷한 형식으로 구현하려고 했습니다!
~~Type 이랑 Color 적용하기 어렵네요...~~

[Booth_Tap_Ui.webm](https://github.com/user-attachments/assets/37f5efab-2cb5-4e21-be4c-2006e19ad247)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 부스 목록 화면이 추가되어, 부스 리스트와 상세 정보를 확인할 수 있습니다.
  * 부스의 웨이팅 가능 여부를 체크박스로 필터링할 수 있습니다.
  * 부스 아이템에 썸네일, 이름, 설명, 위치 정보가 표시됩니다.
  * 네트워크 및 서버 오류 발생 시 에러 다이얼로그와 재시도 기능이 제공됩니다.

* **디자인 및 리소스**
  * 부스 관련 새로운 아이콘과 벡터 이미지가 야간 모드 포함 추가되었습니다.
  * "부스 목록", "총 %d개", "웨이팅 가능 여부" 등의 문자열 리소스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->