### PR TITLE
refactor: Textfield value, onValueChange -> TextFieldState 로 관리하는 방식으로 변경

### DIFF
--- a/core/common/src/main/kotlin/com/unifest/android/core/common/utils/PhoneNumberVisualTransformation.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/utils/PhoneNumberVisualTransformation.kt
@@ -1,13 +1,13 @@
 package com.unifest.android.core.common.utils
 
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TransformedText
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
 
-class PhoneNumberVisualTransformation : VisualTransformation {
-    override fun filter(text: AnnotatedString): TransformedText {
-        val trimmed = if (text.text.length >= 11) text.text.substring(0..10) else text.text
+// https://developer.android.com/develop/ui/compose/quick-guides/content/auto-format-phone-number?hl=ko
+class PhoneNumberVisualTransformation : OutputTransformation {
+    override fun TextFieldBuffer.transformOutput() {
+        val text = toString()
+        val trimmed = if (text.length >= 11) text.substring(0..10) else text
         val out = StringBuilder()
 
         for (i in trimmed.indices) {
@@ -15,26 +15,6 @@ class PhoneNumberVisualTransformation : VisualTransformation {
             if (i == 2 || i == 6) out.append('-')
         }
 
-        val phoneNumberOffsetTranslator = object : OffsetMapping {
-            override fun originalToTransformed(offset: Int): Int {
-                return when {
-                    offset <= 2 -> offset
-                    offset <= 6 -> offset + 1
-                    offset <= 10 -> offset + 2
-                    else -> out.length
-                }
-            }
-
-            override fun transformedToOriginal(offset: Int): Int {
-                return when {
-                    offset <= 3 -> offset
-                    offset <= 8 -> offset - 1
-                    offset <= out.length -> offset - 2
-                    else -> trimmed.length
-                }
-            }
-        }
-
-        return TransformedText(AnnotatedString(out.toString()), phoneNumberOffsetTranslator)
+        replace(0, length, out.toString())
     }
 }

--- a/core/common/src/main/kotlin/com/unifest/android/core/common/utils/SearchUtils.kt
+++ b/core/common/src/main/kotlin/com/unifest/android/core/common/utils/SearchUtils.kt
@@ -1,9 +1,8 @@
 package com.unifest.android.core.common.utils
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalModel
 
-fun matchesSearchText(festival: FestivalModel, searchText: TextFieldValue): Boolean {
-    return festival.schoolName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true) ||
-        festival.festivalName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true)
+fun matchesSearchText(festival: FestivalModel, searchText: String): Boolean {
+    return festival.schoolName.replace(" ", "").contains(searchText.replace(" ", ""), ignoreCase = true) ||
+        festival.festivalName.replace(" ", "").contains(searchText.replace(" ", ""), ignoreCase = true)
 }

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
@@ -15,8 +15,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.Icon
@@ -34,7 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.skydoves.compose.effects.RememberedEffect
 import com.unifest.android.core.designsystem.ComponentPreview
@@ -51,10 +52,9 @@ val unifestTextSelectionColors = TextSelectionColors(
 
 @Composable
 fun SearchTextField(
-    searchText: TextFieldValue,
-    updateSearchText: (TextFieldValue) -> Unit,
+    searchTextState: TextFieldState,
     @StringRes searchTextHintRes: Int,
-    onSearch: (TextFieldValue) -> Unit,
+    onSearch: (String) -> Unit,
     clearSearchText: () -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.background,
@@ -64,26 +64,30 @@ fun SearchTextField(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
+    // TODO 어떻게 20자 제한을 설정할 수 있을까 => InputTransformation!
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
-            value = searchText,
-            onValueChange = {
-                if (it.text.length <= 20) {
-                    updateSearchText(it)
-                }
-            },
+//            value = searchText,
+//            onValueChange = {
+//                if (it.text.length <= 20) {
+//                    updateSearchText(it)
+//                }
+//            },
+            state = searchTextState,
             modifier = Modifier.fillMaxWidth(),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onSearch(searchText)
-                    keyboardController?.hide()
-                },
-            ),
-            singleLine = true,
+            inputTransformation = {},
             textStyle = TextStyle(color = textColor),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Search,
+            ),
+            onKeyboardAction = {
+                onSearch(searchTextState.text.toString())
+                keyboardController?.hide()
+            },
+            lineLimits = TextFieldLineLimits.SingleLine,
             cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
-            decorationBox = { innerTextField ->
+            decorator = { innerTextField ->
                 Row(
                     modifier = modifier
                         .background(color = backgroundColor, shape = cornerShape)
@@ -95,7 +99,7 @@ fun SearchTextField(
                 ) {
                     Spacer(modifier = Modifier.width(17.dp))
                     Box {
-                        if (searchText.text.isEmpty()) {
+                        if (searchTextState.text.isEmpty()) {
                             Text(
                                 text = stringResource(id = searchTextHintRes),
                                 color = MaterialTheme.colorScheme.onSecondaryContainer,
@@ -105,7 +109,7 @@ fun SearchTextField(
                         innerTextField()
                     }
                     Spacer(modifier = Modifier.weight(1f))
-                    if (searchText.text.isEmpty()) {
+                    if (searchTextState.text.isEmpty()) {
                         Icon(
                             imageVector = ImageVector.vectorResource(R.drawable.ic_search),
                             contentDescription = "Search Icon",
@@ -135,8 +139,7 @@ fun SearchTextField(
 
 @Composable
 fun FestivalSearchTextField(
-    searchText: TextFieldValue,
-    updateSearchText: (TextFieldValue) -> Unit,
+    searchTextState: TextFieldState,
     @StringRes searchTextHintRes: Int,
     onSearch: (String) -> Unit,
     clearSearchText: () -> Unit,
@@ -148,24 +151,25 @@ fun FestivalSearchTextField(
     cornerShape: RoundedCornerShape = RoundedCornerShape(67.dp),
     borderStroke: BorderStroke = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.secondaryContainer),
 ) {
-    RememberedEffect(key1 = searchText.text) {
-        setEnableSearchMode(searchText.text.isNotEmpty())
+    RememberedEffect(key1 = searchTextState.text) {
+        setEnableSearchMode(searchTextState.text.isNotEmpty())
     }
 
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
-            value = searchText,
-            onValueChange = {
-                if (it.text.length <= 20) {
-                    updateSearchText(it)
-                }
-            },
+//            value = searchText,
+//            onValueChange = {
+//                if (it.text.length <= 20) {
+//                    updateSearchText(it)
+//                }
+//            },
+            state = searchTextState,
             modifier = Modifier.fillMaxWidth(),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            singleLine = true,
+            lineLimits = TextFieldLineLimits.SingleLine,
             textStyle = TextStyle(color = textColor),
             cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
-            decorationBox = { innerTextField ->
+            decorator = { innerTextField ->
                 Row(
                     modifier = modifier
                         .background(color = backgroundColor, shape = cornerShape)
@@ -188,7 +192,7 @@ fun FestivalSearchTextField(
                     }
                     Spacer(modifier = Modifier.width(12.dp))
                     Box {
-                        if (searchText.text.isEmpty()) {
+                        if (searchTextState.text.isEmpty()) {
                             Text(
                                 text = stringResource(id = searchTextHintRes),
                                 color = MaterialTheme.colorScheme.onSecondaryContainer,
@@ -198,12 +202,12 @@ fun FestivalSearchTextField(
                         innerTextField()
                     }
                     Spacer(modifier = Modifier.weight(1f))
-                    if (searchText.text.isEmpty()) {
+                    if (searchTextState.text.isEmpty()) {
                         Icon(
                             imageVector = ImageVector.vectorResource(R.drawable.ic_search),
                             contentDescription = "Search Icon",
                             modifier = Modifier.clickable {
-                                onSearch(searchText.text)
+                                onSearch(searchTextState.text.toString())
                             },
                         )
                     } else {
@@ -225,11 +229,10 @@ fun FestivalSearchTextField(
 
 @ComponentPreview
 @Composable
-private fun SearchTextFieldPreview() {
+private fun SearchTextFieldEmptyPreview() {
     UnifestTheme {
         SearchTextField(
-            searchText = TextFieldValue(),
-            updateSearchText = {},
+            searchTextState = TextFieldState(""),
             searchTextHintRes = R.string.search_text_hint,
             onSearch = {},
             clearSearchText = {},
@@ -243,11 +246,46 @@ private fun SearchTextFieldPreview() {
 
 @ComponentPreview
 @Composable
-private fun FestivalSearchTextFieldPreview() {
+private fun SearchTextFieldFillPreview() {
+    UnifestTheme {
+        SearchTextField(
+            searchTextState = TextFieldState("건국대학교"),
+            searchTextHintRes = R.string.search_text_hint,
+            onSearch = {},
+            clearSearchText = {},
+            modifier = Modifier
+                .height(46.dp)
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun FestivalSearchTextFieldEmptyPreview() {
     UnifestTheme {
         FestivalSearchTextField(
-            searchText = TextFieldValue("건국대학교"),
-            updateSearchText = {},
+            searchTextState = TextFieldState(""),
+            searchTextHintRes = R.string.search_text_hint,
+            onSearch = {},
+            clearSearchText = {},
+            setEnableSearchMode = {},
+            isSearchMode = true,
+            modifier = Modifier
+                .height(46.dp)
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun FestivalSearchTextFieldFillPreview() {
+    UnifestTheme {
+        FestivalSearchTextField(
+            searchTextState = TextFieldState("건국대학교"),
             searchTextHintRes = R.string.search_text_hint,
             onSearch = {},
             clearSearchText = {},

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/SearchTextField.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
@@ -64,18 +65,15 @@ fun SearchTextField(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    // TODO 어떻게 20자 제한을 설정할 수 있을까 => InputTransformation!
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
-//            value = searchText,
-//            onValueChange = {
-//                if (it.text.length <= 20) {
-//                    updateSearchText(it)
-//                }
-//            },
             state = searchTextState,
             modifier = Modifier.fillMaxWidth(),
-            inputTransformation = {},
+            inputTransformation = InputTransformation {
+                if (length > 20) {
+                    revertAllChanges()
+                }
+            },
             textStyle = TextStyle(color = textColor),
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Text,
@@ -157,14 +155,13 @@ fun FestivalSearchTextField(
 
     CompositionLocalProvider(LocalTextSelectionColors provides unifestTextSelectionColors) {
         BasicTextField(
-//            value = searchText,
-//            onValueChange = {
-//                if (it.text.length <= 20) {
-//                    updateSearchText(it)
-//                }
-//            },
             state = searchTextState,
             modifier = Modifier.fillMaxWidth(),
+            inputTransformation = InputTransformation {
+                if (length > 20) {
+                    revertAllChanges()
+                }
+            },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             lineLimits = TextFieldLineLimits.SingleLine,
             textStyle = TextStyle(color = textColor),
@@ -232,7 +229,7 @@ fun FestivalSearchTextField(
 private fun SearchTextFieldEmptyPreview() {
     UnifestTheme {
         SearchTextField(
-            searchTextState = TextFieldState(""),
+            searchTextState = TextFieldState(),
             searchTextHintRes = R.string.search_text_hint,
             onSearch = {},
             clearSearchText = {},
@@ -266,7 +263,7 @@ private fun SearchTextFieldFillPreview() {
 private fun FestivalSearchTextFieldEmptyPreview() {
     UnifestTheme {
         FestivalSearchTextField(
-            searchTextState = TextFieldState(""),
+            searchTextState = TextFieldState(),
             searchTextHintRes = R.string.search_text_hint,
             onSearch = {},
             clearSearchText = {},

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -66,10 +68,9 @@ import com.unifest.android.core.designsystem.R as designR
 @Composable
 fun WaitingPinDialog(
     boothName: String,
-    pinNumber: String,
+    pinNumberState: TextFieldState,
     isWrongPinInserted: Boolean,
     onDismissRequest: () -> Unit,
-    onPinNumberUpdated: (String) -> Unit,
     onDialogPinButtonClick: () -> Unit,
 ) {
     BasicAlertDialog(
@@ -105,10 +106,15 @@ fun WaitingPinDialog(
             Spacer(modifier = Modifier.height(30.dp))
             Column {
                 BasicTextField(
-                    value = pinNumber,
-                    onValueChange = { input ->
-                        if (input.matches(Regex("^\\d{0,4}\$"))) {
-                            onPinNumberUpdated(input)
+                    state = pinNumberState,
+                    inputTransformation = InputTransformation {
+                        if (length > 4) {
+                            revertAllChanges()
+                        } else {
+                            val text = toString()
+                            if (!text.matches(Regex("^\\d*\$"))) {
+                                revertAllChanges()
+                            }
                         }
                     },
                     modifier = Modifier
@@ -127,8 +133,8 @@ fun WaitingPinDialog(
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Number,
                     ),
-                    decorationBox = { innerTextField ->
-                        if (pinNumber.isEmpty()) {
+                    decorator = { innerTextField ->
+                        if (pinNumberState.text.isEmpty()) {
                             Text(
                                 text = stringResource(id = R.string.waiting_dialog_enter_booth_pin_hint),
                                 color = MaterialTheme.colorScheme.onSecondaryContainer,
@@ -186,13 +192,12 @@ fun WaitingPinDialog(
 fun WaitingDialog(
     boothName: String,
     waitingCount: Long,
-    phoneNumber: String,
+    phoneNumberState: TextFieldState,
     partySize: Long,
     isPrivacyClicked: Boolean,
     onDismissRequest: () -> Unit,
     onWaitingMinusClick: () -> Unit,
     onWaitingPlusClick: () -> Unit,
-    onWaitingTelUpdated: (String) -> Unit,
     onDialogWaitingButtonClick: () -> Unit,
     onPolicyCheckBoxClick: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
@@ -200,7 +205,7 @@ fun WaitingDialog(
     val isButtonEnabled by remember {
         derivedStateOf {
             isPrivacyClicked &&
-                phoneNumber.matches(Regex("^\\d{10,11}$")) &&
+                phoneNumberState.text.toString().matches(Regex("^\\d{10,11}$")) &&
                 partySize in 1..10
         }
     }
@@ -283,10 +288,15 @@ fun WaitingDialog(
             }
             Spacer(modifier = Modifier.height(14.dp))
             BasicTextField(
-                value = phoneNumber,
-                onValueChange = { input ->
-                    if (input.matches(Regex("^\\d{0,11}\$"))) {
-                        onWaitingTelUpdated(input)
+                state = phoneNumberState,
+                inputTransformation = InputTransformation {
+                    if (length > 11) {
+                        revertAllChanges()
+                    } else {
+                        val text = toString()
+                        if (!text.matches(Regex("^\\d*\$"))) {
+                            revertAllChanges()
+                        }
                     }
                 },
                 modifier = Modifier
@@ -305,8 +315,8 @@ fun WaitingDialog(
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                 ),
-                decorationBox = { innerTextField ->
-                    if (phoneNumber.isEmpty()) {
+                decorator = { innerTextField ->
+                    if (phoneNumberState.text.isEmpty()) {
                         Text(
                             text = stringResource(id = R.string.waiting_dialog_telephone_waiting_number_hint),
                             color = MaterialTheme.colorScheme.onSecondary,
@@ -315,7 +325,7 @@ fun WaitingDialog(
                     }
                     innerTextField()
                 },
-                visualTransformation = PhoneNumberVisualTransformation(),
+                outputTransformation = PhoneNumberVisualTransformation(),
             )
             Spacer(modifier = Modifier.height(12.dp))
             Column(
@@ -570,10 +580,9 @@ private fun WaitingPinDialogPreview() {
     UnifestTheme {
         WaitingPinDialog(
             boothName = "컴공 주점",
-            pinNumber = "",
+            pinNumberState = TextFieldState(),
             onDismissRequest = {},
             onDialogPinButtonClick = { },
-            onPinNumberUpdated = { },
             isWrongPinInserted = true,
         )
     }
@@ -586,13 +595,12 @@ private fun WaitingDialogPreview() {
         WaitingDialog(
             boothName = "컴공 주점",
             onDismissRequest = {},
-            phoneNumber = "",
+            phoneNumberState = TextFieldState(),
             waitingCount = 3,
             partySize = 3,
             onDialogWaitingButtonClick = { },
             onWaitingMinusClick = { },
             onWaitingPlusClick = { },
-            onWaitingTelUpdated = { },
             isPrivacyClicked = false,
             onPolicyCheckBoxClick = { },
             onPrivacyPolicyClick = { },

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
@@ -299,8 +299,7 @@ internal fun BoothDetailScreen(
         if (uiState.isPinCheckDialogVisible) {
             WaitingPinDialog(
                 boothName = uiState.boothDetailInfo.name,
-                pinNumber = uiState.boothPinNumber,
-                onPinNumberUpdated = { onAction(BoothDetailUiAction.OnPinNumberUpdated(it)) },
+                pinNumberState = uiState.boothPinNumber,
                 onDialogPinButtonClick = { onAction(BoothDetailUiAction.OnDialogPinButtonClick) },
                 onDismissRequest = { onAction(BoothDetailUiAction.OnPinDialogDismiss) },
                 isWrongPinInserted = uiState.isWrongPinInserted,
@@ -311,14 +310,13 @@ internal fun BoothDetailScreen(
             WaitingDialog(
                 boothName = uiState.boothDetailInfo.name,
                 waitingCount = uiState.waitingTeamNumber,
-                phoneNumber = uiState.waitingTel,
+                phoneNumberState = uiState.waitingTel,
                 partySize = uiState.waitingPartySize,
                 isPrivacyClicked = uiState.privacyConsentChecked,
                 onDismissRequest = { onAction(BoothDetailUiAction.OnWaitingDialogDismiss) },
                 onWaitingMinusClick = { onAction(BoothDetailUiAction.OnWaitingMinusClick) },
                 onWaitingPlusClick = { onAction(BoothDetailUiAction.OnWaitingPlusClick) },
                 onDialogWaitingButtonClick = { onAction(BoothDetailUiAction.OnDialogWaitingButtonClick) },
-                onWaitingTelUpdated = { onAction(BoothDetailUiAction.OnWaitingTelUpdated(it)) },
                 onPolicyCheckBoxClick = { onAction(BoothDetailUiAction.OnPolicyCheckBoxClick) },
                 onPrivacyPolicyClick = { onAction(BoothDetailUiAction.OnPrivatePolicyClick) },
             )

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailUiAction.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailUiAction.kt
@@ -13,8 +13,6 @@ sealed interface BoothDetailUiAction {
     data object OnWaitingButtonClick : BoothDetailUiAction
     data object OnDialogPinButtonClick : BoothDetailUiAction
     data object OnDialogWaitingButtonClick : BoothDetailUiAction
-    data class OnPinNumberUpdated(val pinNumber: String) : BoothDetailUiAction
-    data class OnWaitingTelUpdated(val tel: String) : BoothDetailUiAction
     data object OnWaitingDialogDismiss : BoothDetailUiAction
     data object OnConfirmDialogDismiss : BoothDetailUiAction
     data object OnPinDialogDismiss : BoothDetailUiAction

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailUiState.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailUiState.kt
@@ -1,5 +1,6 @@
 package com.unifest.android.feature.booth_detail.viewmodel
 
+import androidx.compose.foundation.text.input.TextFieldState
 import com.naver.maps.geometry.LatLng
 import com.unifest.android.core.common.HANKYONG_UNIVERSITY_POLYLINE
 import com.unifest.android.core.common.KONKUK_UNIVERSITY_POLYLINE
@@ -27,10 +28,10 @@ data class BoothDetailUiState(
     val isMenuImageDialogVisible: Boolean = false,
     val isWrongPinInserted: Boolean = false,
     val selectedMenu: MenuModel? = null,
-    val boothPinNumber: String = "",
+    val boothPinNumber: TextFieldState = TextFieldState(),
     val boothPinNumberError: Boolean = false,
     val waitingPartySize: Long = 1,
-    val waitingTel: String = "",
+    val waitingTel: TextFieldState = TextFieldState(),
     val waitingTeamNumber: Long = 0,
     val waitingId: Long = 0,
     val privacyConsentChecked: Boolean = false,

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.unifest.android.feature.booth_detail.viewmodel
 
 import android.Manifest
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -58,8 +59,6 @@ class BoothDetailViewModel @Inject constructor(
             is BoothDetailUiAction.OnRetryClick -> refresh(action.error)
             is BoothDetailUiAction.OnMenuImageClick -> showMenuImageDialog(action.menu)
             is BoothDetailUiAction.OnMenuImageDialogDismiss -> hideMenuImageDialog()
-            is BoothDetailUiAction.OnPinNumberUpdated -> updatePinNumberText(action.pinNumber)
-            is BoothDetailUiAction.OnWaitingTelUpdated -> updateWaitingTelText(action.tel)
             is BoothDetailUiAction.OnWaitingButtonClick -> checkMyWaitingListNumbers()
             is BoothDetailUiAction.OnDialogPinButtonClick -> checkPinValidation()
             is BoothDetailUiAction.OnDialogWaitingButtonClick -> requestBoothWaiting()
@@ -241,7 +240,7 @@ class BoothDetailViewModel @Inject constructor(
     }
 
     private fun requestBoothWaiting() {
-        val tel = _uiState.value.waitingTel
+        val tel = _uiState.value.waitingTel.text.toString()
         val partySize = _uiState.value.waitingPartySize
 
         if (isTelValid(tel) && isPartySizeValid(partySize)) {
@@ -250,15 +249,15 @@ class BoothDetailViewModel @Inject constructor(
                     boothId = _uiState.value.boothDetailInfo.id,
                     tel = tel,
                     partySize = partySize,
-                    pinNumber = _uiState.value.boothPinNumber,
+                    pinNumber = _uiState.value.boothPinNumber.text.toString(),
                 ).onSuccess { waiting ->
                     _uiState.update {
                         it.copy(
                             waitingId = waiting.waitingId,
-                            waitingTel = "",
-                            boothPinNumber = "",
                         )
                     }
+                    _uiState.value.waitingTel.clearText()
+                    _uiState.value.boothPinNumber.clearText()
                     waitingRepository.registerFCMTopic(waiting.waitingId.toString())
                     setWaitingDialogVisible(false)
                     setConfirmDialogVisible(true)
@@ -281,21 +280,6 @@ class BoothDetailViewModel @Inject constructor(
         return partySize >= 1
     }
 
-    private fun updatePinNumberText(pinNumber: String) {
-        _uiState.update {
-            it.copy(
-                boothPinNumber = pinNumber,
-            )
-        }
-    }
-
-    private fun updateWaitingTelText(tel: String) {
-        _uiState.update {
-            it.copy(
-                waitingTel = tel,
-            )
-        }
-    }
 
     private fun checkPinValidation() {
         if (_uiState.value.isWrongPinInserted) {
@@ -303,7 +287,7 @@ class BoothDetailViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            boothRepository.checkPinValidation(_uiState.value.boothDetailInfo.id, _uiState.value.boothPinNumber)
+            boothRepository.checkPinValidation(_uiState.value.boothDetailInfo.id, _uiState.value.boothPinNumber.text.toString())
                 .onSuccess { waitingTeamNumber ->
                     if (waitingTeamNumber > -1) {
                         _uiState.update {
@@ -313,11 +297,9 @@ class BoothDetailViewModel @Inject constructor(
                         setWaitingDialogVisible(true)
                     } else {
                         _uiState.update {
-                            it.copy(
-                                isWrongPinInserted = true,
-                                boothPinNumber = "",
-                            )
+                            it.copy(isWrongPinInserted = true)
                         }
+                        _uiState.value.boothPinNumber.clearText()
                         delay(2000L)
                         _uiState.update {
                             it.copy(isWrongPinInserted = false)

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
@@ -280,7 +280,6 @@ class BoothDetailViewModel @Inject constructor(
         return partySize >= 1
     }
 
-
     private fun checkPinValidation() {
         if (_uiState.value.isWrongPinInserted) {
             return

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/FestivalBottomSheet.kt
@@ -89,8 +89,8 @@ fun FestivalSearchBottomSheet(
         ) {
             Spacer(modifier = Modifier.height(24.dp))
             FestivalSearchTextField(
-                searchText = uiState.festivalSearchText,
-                updateSearchText = { text -> onFestivalUiAction(FestivalUiAction.OnSearchTextUpdated(text)) },
+                searchTextState = uiState.festivalSearchText,
+                // updateSearchText = { text -> onFestivalUiAction(FestivalUiAction.OnSearchTextUpdated(text)) },
                 searchTextHintRes = designR.string.festival_search_text_field_hint,
                 onSearch = {},
                 clearSearchText = { onFestivalUiAction(FestivalUiAction.OnSearchTextCleared) },

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiAction.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiAction.kt
@@ -5,7 +5,6 @@ import com.unifest.android.core.model.FestivalModel
 sealed interface FestivalUiAction {
     data object OnAddLikedFestivalClick : FestivalUiAction
     data object OnDismiss : FestivalUiAction
-    // data class OnSearchTextUpdated(val searchText: String) : FestivalUiAction
     data object OnSearchTextCleared : FestivalUiAction
     data object OnTooltipClick : FestivalUiAction
     data class OnEnableSearchMode(val flag: Boolean) : FestivalUiAction

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiAction.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiAction.kt
@@ -1,12 +1,11 @@
 package com.unifest.android.feature.festival.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalModel
 
 sealed interface FestivalUiAction {
     data object OnAddLikedFestivalClick : FestivalUiAction
     data object OnDismiss : FestivalUiAction
-    data class OnSearchTextUpdated(val searchText: TextFieldValue) : FestivalUiAction
+    // data class OnSearchTextUpdated(val searchText: String) : FestivalUiAction
     data object OnSearchTextCleared : FestivalUiAction
     data object OnTooltipClick : FestivalUiAction
     data class OnEnableSearchMode(val flag: Boolean) : FestivalUiAction

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
@@ -1,14 +1,14 @@
 package com.unifest.android.feature.festival.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
-import com.unifest.android.core.designsystem.R as designR
+import androidx.compose.foundation.text.input.TextFieldState
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import com.unifest.android.core.designsystem.R as designR
 
 data class FestivalUiState(
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
-    val festivalSearchText: TextFieldValue = TextFieldValue(),
+    val festivalSearchText: TextFieldState = TextFieldState(""),
     val searchTextHintRes: Int = designR.string.festival_search_text_field_hint,
     val likedFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalUiState.kt
@@ -8,7 +8,7 @@ import com.unifest.android.core.designsystem.R as designR
 
 data class FestivalUiState(
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
-    val festivalSearchText: TextFieldState = TextFieldState(""),
+    val festivalSearchText: TextFieldState = TextFieldState(),
     val searchTextHintRes: Int = designR.string.festival_search_text_field_hint,
     val likedFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
@@ -1,12 +1,11 @@
 package com.unifest.android.feature.festival.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.common.handleException
-import com.unifest.android.core.common.utils.matchesSearchText
 import com.unifest.android.core.data.api.repository.FestivalRepository
 import com.unifest.android.core.data.api.repository.LikedFestivalRepository
 import com.unifest.android.core.data.api.repository.OnboardingRepository
@@ -52,7 +51,7 @@ class FestivalViewModel @Inject constructor(
         when (action) {
             is FestivalUiAction.OnAddLikedFestivalClick -> setFestivalSearchBottomSheetVisible(true)
             is FestivalUiAction.OnDismiss -> setFestivalSearchBottomSheetVisible(false)
-            is FestivalUiAction.OnSearchTextUpdated -> updateFestivalSearchText(action.searchText)
+            // is FestivalUiAction.OnSearchTextUpdated -> updateFestivalSearchText(action.searchText)
             is FestivalUiAction.OnSearchTextCleared -> clearFestivalSearchText()
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
@@ -99,21 +98,22 @@ class FestivalViewModel @Inject constructor(
         }
     }
 
-    private fun updateFestivalSearchText(searchText: TextFieldValue) {
-        _uiState.update {
-            it.copy(
-                festivalSearchText = searchText,
-                festivalSearchResults = it.festivals.filter { festival ->
-                    matchesSearchText(festival, searchText)
-                }.toImmutableList(),
-            )
-        }
-    }
+//    private fun updateFestivalSearchText(searchText: String) {
+//        _uiState.update {
+//            it.copy(
+//                festivalSearchText = searchText,
+//                festivalSearchResults = it.festivals.filter { festival ->
+//                    matchesSearchText(festival, searchText)
+//                }.toImmutableList(),
+//            )
+//        }
+//    }
 
     private fun clearFestivalSearchText() {
         _uiState.update {
             it.copy(
-                festivalSearchText = TextFieldValue(),
+                // TODO .clearText() 로 처리해야 함
+                festivalSearchText = TextFieldState(),
                 festivalSearchResults = persistentListOf(),
             )
         }

--- a/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
+++ b/feature/festival/src/main/kotlin/com/unifest/android/feature/festival/viewmodel/FestivalViewModel.kt
@@ -1,6 +1,6 @@
 package com.unifest.android.feature.festival.viewmodel
 
-import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
@@ -51,7 +51,6 @@ class FestivalViewModel @Inject constructor(
         when (action) {
             is FestivalUiAction.OnAddLikedFestivalClick -> setFestivalSearchBottomSheetVisible(true)
             is FestivalUiAction.OnDismiss -> setFestivalSearchBottomSheetVisible(false)
-            // is FestivalUiAction.OnSearchTextUpdated -> updateFestivalSearchText(action.searchText)
             is FestivalUiAction.OnSearchTextCleared -> clearFestivalSearchText()
             is FestivalUiAction.OnEnableSearchMode -> setEnableSearchMode(action.flag)
             is FestivalUiAction.OnEnableEditMode -> setEnableEditMode()
@@ -98,25 +97,9 @@ class FestivalViewModel @Inject constructor(
         }
     }
 
-//    private fun updateFestivalSearchText(searchText: String) {
-//        _uiState.update {
-//            it.copy(
-//                festivalSearchText = searchText,
-//                festivalSearchResults = it.festivals.filter { festival ->
-//                    matchesSearchText(festival, searchText)
-//                }.toImmutableList(),
-//            )
-//        }
-//    }
-
     private fun clearFestivalSearchText() {
-        _uiState.update {
-            it.copy(
-                // TODO .clearText() 로 처리해야 함
-                festivalSearchText = TextFieldState(),
-                festivalSearchResults = persistentListOf(),
-            )
-        }
+        _uiState.value.festivalSearchText.clearText()
+        _uiState.update { it.copy(festivalSearchResults = persistentListOf()) }
     }
 
     private fun setFestivalSearchBottomSheetVisible(flag: Boolean) {

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -1,6 +1,6 @@
 package com.unifest.android.feature.home.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.StarInfoModel
@@ -12,7 +12,7 @@ data class HomeUiState(
     val incomingFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val todayFestivals: ImmutableList<FestivalTodayModel> = persistentListOf(),
     val allFestivals: ImmutableList<FestivalModel> = persistentListOf(),
-    val festivalSearchText: TextFieldValue = TextFieldValue(),
+    val festivalSearchText: TextFieldState = TextFieldState(""),
     val likedFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val deleteSelectedFestival: FestivalModel? = null,
     val selectedDate: LocalDate = LocalDate.now(),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -12,7 +12,7 @@ data class HomeUiState(
     val incomingFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val todayFestivals: ImmutableList<FestivalTodayModel> = persistentListOf(),
     val allFestivals: ImmutableList<FestivalModel> = persistentListOf(),
-    val festivalSearchText: TextFieldState = TextFieldState(""),
+    val festivalSearchText: TextFieldState = TextFieldState(),
     val likedFestivals: ImmutableList<FestivalModel> = persistentListOf(),
     val deleteSelectedFestival: FestivalModel? = null,
     val selectedDate: LocalDate = LocalDate.now(),

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -142,10 +142,12 @@ internal fun IntroContent(
                 )
             }
             SearchTextField(
-                searchText = uiState.searchText,
-                updateSearchText = { text -> onAction(IntroUiAction.OnSearchTextUpdated(text)) },
+                searchTextState = uiState.searchTextState,
+                // updateSearchText = { text -> onAction(IntroUiAction.OnSearchTextUpdated(text)) },
                 searchTextHintRes = designR.string.search_text_hint,
-                onSearch = { onAction(IntroUiAction.OnSearch(it)) },
+                onSearch = {
+                    onAction(IntroUiAction.OnSearch(it))
+                },
                 clearSearchText = { onAction(IntroUiAction.OnSearchTextCleared) },
                 modifier = Modifier
                     .height(46.dp)

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/IntroScreen.kt
@@ -143,7 +143,6 @@ internal fun IntroContent(
             }
             SearchTextField(
                 searchTextState = uiState.searchTextState,
-                // updateSearchText = { text -> onAction(IntroUiAction.OnSearchTextUpdated(text)) },
                 searchTextHintRes = designR.string.search_text_hint,
                 onSearch = {
                     onAction(IntroUiAction.OnSearch(it))

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiAction.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiAction.kt
@@ -1,12 +1,11 @@
 package com.unifest.android.feature.intro.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.model.FestivalModel
 
 sealed interface IntroUiAction {
-    data class OnSearchTextUpdated(val searchText: TextFieldValue) : IntroUiAction
+    // data class OnSearchTextUpdated(val searchText: TextFieldValue) : IntroUiAction
     data object OnSearchTextCleared : IntroUiAction
-    data class OnSearch(val searchText: TextFieldValue) : IntroUiAction
+    data class OnSearch(val searchText: String) : IntroUiAction
     data class OnRegionTapClicked(val region: String) : IntroUiAction
     data object OnClearSelectionClick : IntroUiAction
     data class OnFestivalSelected(val festival: FestivalModel) : IntroUiAction

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiAction.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiAction.kt
@@ -3,7 +3,6 @@ package com.unifest.android.feature.intro.viewmodel
 import com.unifest.android.core.model.FestivalModel
 
 sealed interface IntroUiAction {
-    // data class OnSearchTextUpdated(val searchText: TextFieldValue) : IntroUiAction
     data object OnSearchTextCleared : IntroUiAction
     data class OnSearch(val searchText: String) : IntroUiAction
     data class OnRegionTapClicked(val region: String) : IntroUiAction

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
@@ -9,7 +9,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class IntroUiState(
     val isLoading: Boolean = false,
     val isSearchLoading: Boolean = false,
-    val searchTextState: TextFieldState = TextFieldState(""),
+    val searchTextState: TextFieldState = TextFieldState(),
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedFestivals: PersistentList<FestivalModel> = persistentListOf(),
     val selectedRegion: String = "전체",

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroUiState.kt
@@ -1,6 +1,6 @@
 package com.unifest.android.feature.intro.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
 import com.unifest.android.core.model.FestivalModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
@@ -9,7 +9,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class IntroUiState(
     val isLoading: Boolean = false,
     val isSearchLoading: Boolean = false,
-    val searchText: TextFieldValue = TextFieldValue(),
+    val searchTextState: TextFieldState = TextFieldState(""),
     val festivals: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedFestivals: PersistentList<FestivalModel> = persistentListOf(),
     val selectedRegion: String = "전체",

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -1,6 +1,6 @@
 package com.unifest.android.feature.intro.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
@@ -40,9 +40,9 @@ class IntroViewModel @Inject constructor(
 
     fun onAction(action: IntroUiAction) {
         when (action) {
-            is IntroUiAction.OnSearchTextUpdated -> updateSearchText(action.searchText)
+            // is IntroUiAction.OnSearchTextUpdated -> updateSearchText(action.searchText)
             is IntroUiAction.OnSearchTextCleared -> clearSearchText()
-            is IntroUiAction.OnSearch -> searchSchool(action.searchText.text)
+            is IntroUiAction.OnSearch -> searchSchool(action.searchText)
             is IntroUiAction.OnRegionTapClicked -> searchRegion(action.region)
             is IntroUiAction.OnClearSelectionClick -> clearSelectedFestivals()
             is IntroUiAction.OnFestivalSelected -> addSelectedFestival(action.festival)
@@ -52,16 +52,14 @@ class IntroViewModel @Inject constructor(
         }
     }
 
-    private fun updateSearchText(text: TextFieldValue) {
-        _uiState.update {
-            it.copy(searchText = text)
-        }
-    }
+//    private fun updateSearchText(text: TextFieldValue) {
+//        _uiState.update {
+//            it.copy(searchTextState = text)
+//        }
+//    }
 
     private fun clearSearchText() {
-        _uiState.update {
-            it.copy(searchText = TextFieldValue())
-        }
+        _uiState.value.searchTextState.clearText()
     }
 
     private fun getAllFestivals() {
@@ -128,15 +126,15 @@ class IntroViewModel @Inject constructor(
                 }
                 festivalRepository.searchRegion(region)
                     .onSuccess { festivals ->
-                        if (_uiState.value.searchText.text.isEmpty()) {
+                        if (_uiState.value.searchTextState.text.isEmpty()) {
                             _uiState.update {
                                 it.copy(festivals = festivals.toImmutableList())
                             }
                         } else {
                             festivals.filter { festival ->
                                 // 축제 이름이 영어 일 수 있으므로, 영어 대소문자를 구분하지 않는 옵션(ignoreCase = true) 추가
-                                festival.schoolName.contains(_uiState.value.searchText.text, ignoreCase = true) ||
-                                    festival.festivalName.contains(_uiState.value.searchText.text, ignoreCase = true)
+                                festival.schoolName.contains(_uiState.value.searchTextState.text, ignoreCase = true) ||
+                                    festival.festivalName.contains(_uiState.value.searchTextState.text, ignoreCase = true)
                             }.let { filteredFestivals ->
                                 _uiState.update {
                                     it.copy(festivals = filteredFestivals.toImmutableList())

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -40,7 +40,6 @@ class IntroViewModel @Inject constructor(
 
     fun onAction(action: IntroUiAction) {
         when (action) {
-            // is IntroUiAction.OnSearchTextUpdated -> updateSearchText(action.searchText)
             is IntroUiAction.OnSearchTextCleared -> clearSearchText()
             is IntroUiAction.OnSearch -> searchSchool(action.searchText)
             is IntroUiAction.OnRegionTapClicked -> searchRegion(action.region)
@@ -51,12 +50,6 @@ class IntroViewModel @Inject constructor(
             is IntroUiAction.OnRetryClick -> refresh(action.error)
         }
     }
-
-//    private fun updateSearchText(text: TextFieldValue) {
-//        _uiState.update {
-//            it.copy(searchTextState = text)
-//        }
-//    }
 
     private fun clearSearchText() {
         _uiState.value.searchTextState.clearText()

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/MapScreen.kt
@@ -538,7 +538,7 @@ internal fun MapContent(
         }
         MapTopAppBar(
             title = uiState.festivalInfo.schoolName,
-            boothSearchText = uiState.boothSearchText,
+            boothSearchTextState = uiState.boothSearchTextState,
             onMapUiAction = onMapUiAction,
             onFestivalUiAction = onFestivalUiAction,
             isOnboardingCompleted = uiState.isMapOnboardingCompleted,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -55,7 +56,6 @@ internal fun MapTopAppBar(
             )
             SearchTextField(
                 searchTextState = boothSearchTextState,
-                // updateSearchText = { text -> onMapUiAction(MapUiAction.OnSearchTextUpdated(text)) },
                 searchTextHintRes = R.string.map_booth_search_text_field_hint,
                 onSearch = { onMapUiAction(MapUiAction.OnSearch(boothSearchTextState.text.toString())) },
                 clearSearchText = { onMapUiAction(MapUiAction.OnSearchTextCleared) },
@@ -83,7 +83,7 @@ private fun MapTopAppBarPreview() {
     UnifestTheme {
         MapTopAppBar(
             title = "건국대학교",
-            boothSearchTextState = TextFieldState(""),
+            boothSearchTextState = TextFieldState(),
             isOnboardingCompleted = false,
             onMapUiAction = {},
             onFestivalUiAction = {},

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
@@ -7,12 +7,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.component.SearchTextField
@@ -29,7 +29,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun MapTopAppBar(
     title: String,
-    boothSearchText: TextFieldValue,
+    boothSearchTextState: TextFieldState,
     isOnboardingCompleted: Boolean,
     onMapUiAction: (MapUiAction) -> Unit,
     onFestivalUiAction: (FestivalUiAction) -> Unit,
@@ -54,10 +54,10 @@ internal fun MapTopAppBar(
                 onTooltipClick = { onMapUiAction(MapUiAction.OnTooltipClick) },
             )
             SearchTextField(
-                searchText = boothSearchText,
-                updateSearchText = { text -> onMapUiAction(MapUiAction.OnSearchTextUpdated(text)) },
+                searchTextState = boothSearchTextState,
+                // updateSearchText = { text -> onMapUiAction(MapUiAction.OnSearchTextUpdated(text)) },
                 searchTextHintRes = R.string.map_booth_search_text_field_hint,
-                onSearch = { onMapUiAction(MapUiAction.OnSearch(boothSearchText)) },
+                onSearch = { onMapUiAction(MapUiAction.OnSearch(boothSearchTextState.text.toString())) },
                 clearSearchText = { onMapUiAction(MapUiAction.OnSearchTextCleared) },
                 modifier = Modifier
                     .height(46.dp)
@@ -83,7 +83,7 @@ private fun MapTopAppBarPreview() {
     UnifestTheme {
         MapTopAppBar(
             title = "건국대학교",
-            boothSearchText = TextFieldValue(),
+            boothSearchTextState = TextFieldState(""),
             isOnboardingCompleted = false,
             onMapUiAction = {},
             onFestivalUiAction = {},

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/MapTopAppBar.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiAction.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiAction.kt
@@ -1,14 +1,13 @@
 package com.unifest.android.feature.map.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.unifest.android.core.common.PermissionDialogButtonType
 import com.unifest.android.feature.map.model.BoothMapModel
 
 sealed interface MapUiAction {
     data object OnTooltipClick : MapUiAction
-    data class OnSearchTextUpdated(val searchText: TextFieldValue) : MapUiAction
+    // data class OnSearchTextUpdated(val searchText: TextFieldValue) : MapUiAction
     data object OnSearchTextCleared : MapUiAction
-    data class OnSearch(val searchText: TextFieldValue) : MapUiAction
+    data class OnSearch(val searchText: String) : MapUiAction
     data class OnBoothMarkerClick(val booths: List<BoothMapModel>) : MapUiAction
 
     data class OnSingleBoothMarkerClick(val booth: BoothMapModel) : MapUiAction

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiAction.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiAction.kt
@@ -5,7 +5,6 @@ import com.unifest.android.feature.map.model.BoothMapModel
 
 sealed interface MapUiAction {
     data object OnTooltipClick : MapUiAction
-    // data class OnSearchTextUpdated(val searchText: TextFieldValue) : MapUiAction
     data object OnSearchTextCleared : MapUiAction
     data class OnSearch(val searchText: String) : MapUiAction
     data class OnBoothMarkerClick(val booths: List<BoothMapModel>) : MapUiAction

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -19,7 +19,7 @@ data class MapUiState(
     val boothList: ImmutableList<BoothMapModel> = persistentListOf(),
     val popularBoothList: ImmutableList<BoothModel> = persistentListOf(),
     val selectedBoothList: ImmutableList<BoothMapModel> = persistentListOf(),
-    val boothSearchTextState: TextFieldState = TextFieldState(""),
+    val boothSearchTextState: TextFieldState = TextFieldState(),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedBoothTypeChips: ImmutableList<String> = persistentListOf("주점", "먹거리", "이벤트", "일반"),
     val filteredBoothList: ImmutableList<BoothMapModel> = persistentListOf(),

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapUiState.kt
@@ -1,6 +1,6 @@
 package com.unifest.android.feature.map.viewmodel
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
 import com.naver.maps.geometry.LatLng
 import com.unifest.android.core.common.HANKYONG_UNIVERSITY_POLYLINE
 import com.unifest.android.core.common.KONKUK_UNIVERSITY_POLYLINE
@@ -19,7 +19,7 @@ data class MapUiState(
     val boothList: ImmutableList<BoothMapModel> = persistentListOf(),
     val popularBoothList: ImmutableList<BoothModel> = persistentListOf(),
     val selectedBoothList: ImmutableList<BoothMapModel> = persistentListOf(),
-    val boothSearchText: TextFieldValue = TextFieldValue(),
+    val boothSearchTextState: TextFieldState = TextFieldState(""),
     val festivalSearchResults: ImmutableList<FestivalModel> = persistentListOf(),
     val selectedBoothTypeChips: ImmutableList<String> = persistentListOf("주점", "먹거리", "이벤트", "일반"),
     val filteredBoothList: ImmutableList<BoothMapModel> = persistentListOf(),

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -1,7 +1,7 @@
 package com.unifest.android.feature.map.viewmodel
 
 import android.Manifest
-import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
@@ -55,7 +55,6 @@ class MapViewModel @Inject constructor(
 
     fun onMapUiAction(action: MapUiAction) {
         when (action) {
-            // is MapUiAction.OnSearchTextUpdated -> updateBoothSearchText(action.searchText)
             is MapUiAction.OnSearchTextCleared -> clearBoothSearchText()
             is MapUiAction.OnSearch -> searchBooth()
             is MapUiAction.OnTooltipClick -> completeMapOnboarding()
@@ -254,23 +253,8 @@ class MapViewModel @Inject constructor(
         }
     }
 
-//    private fun updateBoothSearchText(searchText: String) {
-//        _uiState.update {
-//            it.copy(
-//                boothSearchTextState = searchText,
-//                festivalSearchResults = it.festivals.filter { festival ->
-//                    festival.schoolName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true) ||
-//                        festival.festivalName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true)
-//                }.toImmutableList(),
-//            )
-//        }
-//    }
-
     private fun clearBoothSearchText() {
-        // TODO .clearText() 로 처리해줘야 함
-        _uiState.update {
-            it.copy(boothSearchTextState = TextFieldState(""))
-        }
+        _uiState.value.boothSearchTextState.clearText()
     }
 
     private fun searchBooth() {

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/viewmodel/MapViewModel.kt
@@ -1,7 +1,7 @@
 package com.unifest.android.feature.map.viewmodel
 
 import android.Manifest
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
@@ -55,7 +55,7 @@ class MapViewModel @Inject constructor(
 
     fun onMapUiAction(action: MapUiAction) {
         when (action) {
-            is MapUiAction.OnSearchTextUpdated -> updateBoothSearchText(action.searchText)
+            // is MapUiAction.OnSearchTextUpdated -> updateBoothSearchText(action.searchText)
             is MapUiAction.OnSearchTextCleared -> clearBoothSearchText()
             is MapUiAction.OnSearch -> searchBooth()
             is MapUiAction.OnTooltipClick -> completeMapOnboarding()
@@ -254,28 +254,29 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    private fun updateBoothSearchText(searchText: TextFieldValue) {
-        _uiState.update {
-            it.copy(
-                boothSearchText = searchText,
-                festivalSearchResults = it.festivals.filter { festival ->
-                    festival.schoolName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true) ||
-                        festival.festivalName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true)
-                }.toImmutableList(),
-            )
-        }
-    }
+//    private fun updateBoothSearchText(searchText: String) {
+//        _uiState.update {
+//            it.copy(
+//                boothSearchTextState = searchText,
+//                festivalSearchResults = it.festivals.filter { festival ->
+//                    festival.schoolName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true) ||
+//                        festival.festivalName.replace(" ", "").contains(searchText.text.replace(" ", ""), ignoreCase = true)
+//                }.toImmutableList(),
+//            )
+//        }
+//    }
 
     private fun clearBoothSearchText() {
+        // TODO .clearText() 로 처리해줘야 함
         _uiState.update {
-            it.copy(boothSearchText = TextFieldValue())
+            it.copy(boothSearchTextState = TextFieldState(""))
         }
     }
 
     private fun searchBooth() {
         val searchBoothResult = _uiState.value.boothList.filter {
-            it.name.replace(" ", "").contains(_uiState.value.boothSearchText.text.replace(" ", ""), ignoreCase = true) ||
-                it.description.replace(" ", "").contains(_uiState.value.boothSearchText.text.replace(" ", ""), ignoreCase = true)
+            it.name.replace(" ", "").contains(_uiState.value.boothSearchTextState.text.toString().replace(" ", ""), ignoreCase = true) ||
+                it.description.replace(" ", "").contains(_uiState.value.boothSearchTextState.text.toString().replace(" ", ""), ignoreCase = true)
         }
         updateSelectedBoothList(searchBoothResult)
         if (searchBoothResult.isEmpty()) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ androidx-datastore = "1.1.7"
 androidx-room = "2.7.2"
 androidx-activity-compose = "1.10.1"
 androidx-compose = "1.7.4"
-androidx-compose-material3 = "1.4.0-alpha17"
+androidx-compose-material3 = "1.4.0-alpha18"
 androidx-hilt-navigation-compose = "1.2.0"
 androidx-test-core = "1.6.1"
 


### PR DESCRIPTION
- [공식문서에서 권장하는 TextfieldState](https://developer.android.com/develop/ui/compose/text/user-input?hl=ko&textfield=state-based) 방식으로 앱내 사용하던 전체 TextField 변경 완료 하였습니다. 

- 맵화면, 축제 검색화면 등의 Textfield는 문제없이 정상 동작함을 확인하였는데, 웨이팅이 현재 활성화되어있는 부스가 없어 웨이팅쪽 Textfield는 이후 추가 확인이 필요합니다.