### PR TITLE
[feat] 홈 UI 요구사항 반영

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Font.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/theme/Font.kt
@@ -172,6 +172,12 @@ val Content9 = TextStyle(
     fontSize = 14.sp,
 )
 
+val Content10 = TextStyle(
+    fontFamily = pretendardFamily,
+    fontWeight = FontWeight.Medium,
+    fontSize = 14.sp,
+)
+
 val WaitingNumber = TextStyle(
     fontFamily = pretendardFamily,
     fontWeight = FontWeight.SemiBold,

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/CardNewsModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/CardNewsModel.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
 @Stable
 @Serializable
 data class CardNewsModel(
-    val coverImgUrl : String = "",
-    val originalUrl : String = "",
+    val coverImgUrl: String = "",
+    val originalUrl: String = "",
 )

--- a/core/model/src/main/kotlin/com/unifest/android/core/model/CardNewsModel.kt
+++ b/core/model/src/main/kotlin/com/unifest/android/core/model/CardNewsModel.kt
@@ -1,0 +1,11 @@
+package com.unifest.android.core.model
+
+import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
+
+@Stable
+@Serializable
+data class CardNewsModel(
+    val coverImgUrl : String = "",
+    val originalUrl : String = "",
+)

--- a/core/navigation/src/main/kotlin/com/unifest/android/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/kotlin/com/unifest/android/core/navigation/RouteModel.kt
@@ -14,6 +14,9 @@ sealed interface Route {
 
     @Serializable
     data object LikeBooth : Route
+
+    @Serializable
+    data class HomeCardNews(val imgUrl: String) : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
         libs.kotlinx.collections.immutable,
         libs.timber,
+        libs.coil.compose,
         libs.calendar.compose,
     )
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeCardNewsScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeCardNewsScreen.kt
@@ -79,7 +79,7 @@ internal fun HomeCardNewsScreen(
                 .background(Color.Black)
                 .align(Alignment.TopEnd)
                 .clickable(onClick = { popBackStack() })
-                .padding(20.dp),
+                .padding(16.dp),
             painter = painterResource(id = R.drawable.ic_close_24),
             contentDescription = null,
             tint = Color.Unspecified,

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeCardNewsScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeCardNewsScreen.kt
@@ -1,0 +1,104 @@
+package com.unifest.android.feature.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.ui.DevicePreview
+import com.unifest.android.feature.home.component.OriginalCardNews
+
+@Composable
+internal fun HomeCardNewsRoute(
+    popBackStack: () -> Unit,
+    imageUrl: String,
+) {
+    val density = LocalDensity.current
+
+    val screenWidth = LocalWindowInfo.current.containerSize.width
+    val screenHeight = LocalWindowInfo.current.containerSize.height
+    val insets = WindowInsets.systemBars.asPaddingValues()
+
+    val usableHeight = with(density) {
+        (screenHeight.toDp() -
+            insets.calculateTopPadding() - insets.calculateBottomPadding())
+            .toPx()
+            .toInt()
+    }
+
+    HomeCardNewsScreen(
+        imageUrl = imageUrl,
+        screenWidth = screenWidth,
+        screenHeight = usableHeight,
+        popBackStack = popBackStack,
+    )
+}
+
+@Composable
+internal fun HomeCardNewsScreen(
+    imageUrl: String,
+    screenWidth: Int,
+    screenHeight: Int,
+    popBackStack: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .background(Color.Black)
+            .systemBarsPadding()
+            .fillMaxSize(),
+    ) {
+        OriginalCardNews(
+            modifier = Modifier
+                .fillMaxSize()
+                .clipToBounds(),
+            imageUrl = imageUrl,
+            screenWidth = screenWidth,
+            screenHeight = screenHeight,
+        )
+
+        Icon(
+            modifier = Modifier
+                .padding(10.dp)
+                .clip(CircleShape)
+                .background(Color.Black)
+                .align(Alignment.TopEnd)
+                .clickable(onClick = { popBackStack() })
+                .padding(20.dp),
+            painter = painterResource(id = R.drawable.ic_close_24),
+            contentDescription = null,
+            tint = Color.Unspecified,
+        )
+    }
+}
+
+@DevicePreview
+@Composable
+private fun HomeCardNewsPreview() {
+    UnifestTheme {
+        val screenWidth = LocalWindowInfo.current.containerSize.width
+        val screenHeight = LocalWindowInfo.current.containerSize.height
+
+        HomeCardNewsScreen(
+            imageUrl = "https://example.com/image.jpg",
+            popBackStack = {},
+            screenWidth = screenWidth,
+            screenHeight = screenHeight,
+        )
+    }
+}

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -134,6 +136,8 @@ internal fun HomeContent(
     onHomeUiAction: (HomeUiAction) -> Unit,
     onFestivalUiAction: (FestivalUiAction) -> Unit,
 ) {
+    val isGacheonUniv by remember { mutableStateOf(true) }
+
     LazyColumn {
         item {
             Calendar(
@@ -210,40 +214,45 @@ internal fun HomeContent(
                 }
             }
         }
-        item {
-            UnifestOutlinedButton(
-                onClick = { onFestivalUiAction(FestivalUiAction.OnAddLikedFestivalClick) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(20.dp),
-                contentColor = MaterialTheme.colorScheme.onSecondary,
-                borderColor = MaterialTheme.colorScheme.secondaryContainer,
-            ) {
-                Text(
-                    text = stringResource(id = R.string.home_add_interest_festival_button),
-                    style = BoothLocation,
+
+        if (isGacheonUniv) {
+
+        } else {
+            item {
+                UnifestOutlinedButton(
+                    onClick = { onFestivalUiAction(FestivalUiAction.OnAddLikedFestivalClick) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    contentColor = MaterialTheme.colorScheme.onSecondary,
+                    borderColor = MaterialTheme.colorScheme.secondaryContainer,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.home_add_interest_festival_button),
+                        style = BoothLocation,
+                    )
+                }
+            }
+            item {
+                HorizontalDivider(
+                    thickness = 8.dp,
+                    color = MaterialTheme.colorScheme.outline,
                 )
             }
-        }
-        item {
-            HorizontalDivider(
-                thickness = 8.dp,
-                color = MaterialTheme.colorScheme.outline,
-            )
-        }
-        item { Spacer(modifier = Modifier.height(20.dp)) }
-        item {
-            Text(
-                text = stringResource(id = R.string.home_incoming_festival_text),
-                modifier = Modifier.padding(start = 20.dp, bottom = 16.dp),
-                color = MaterialTheme.colorScheme.onBackground,
-                style = Title3,
-            )
-        }
-        if (homeUiState.incomingFestivals.isNotEmpty()) {
-            items(homeUiState.incomingFestivals) { festival ->
-                IncomingFestivalCard(festival = festival)
-                Spacer(modifier = Modifier.height(8.dp))
+            item { Spacer(modifier = Modifier.height(20.dp)) }
+            item {
+                Text(
+                    text = stringResource(id = R.string.home_incoming_festival_text),
+                    modifier = Modifier.padding(start = 20.dp, bottom = 16.dp),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = Title3,
+                )
+            }
+            if (homeUiState.incomingFestivals.isNotEmpty()) {
+                items(homeUiState.incomingFestivals) { festival ->
+                    IncomingFestivalCard(festival = festival)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import com.unifest.android.feature.festival.viewmodel.FestivalUiState
 import com.unifest.android.feature.festival.viewmodel.FestivalViewModel
 import com.unifest.android.feature.home.component.Calendar
 import com.unifest.android.feature.home.component.FestivalScheduleItem
+import com.unifest.android.feature.home.component.HomeCardNews
 import com.unifest.android.feature.home.component.IncomingFestivalCard
 import com.unifest.android.feature.home.component.StarImageDialog
 import com.unifest.android.feature.home.component.TipComponent
@@ -226,6 +227,15 @@ internal fun HomeContent(
                     tipMessage = "",
                 )
             }
+            item {
+                HomeCardNews(
+                    cardNewsList = homeUiState.cardNews,
+                    onCardNewClick = { cardNews ->
+                        onHomeUiAction(HomeUiAction.OnCardNewsClick(cardNews))
+                    },
+                )
+            }
+            item { Spacer(modifier = Modifier.height(50.dp)) }
         } else {
             item {
                 UnifestOutlinedButton(

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -64,6 +64,7 @@ import java.time.format.DateTimeFormatter
 internal fun HomeRoute(
     padding: PaddingValues,
     popBackStack: () -> Unit,
+    navigateToHomeCardNews: (String) -> Unit,
     onShowSnackBar: (message: UiText) -> Unit,
     homeViewModel: HomeViewModel = hiltViewModel(),
     festivalViewModel: FestivalViewModel = hiltViewModel(),
@@ -76,6 +77,7 @@ internal fun HomeRoute(
     ObserveAsEvents(flow = homeViewModel.uiEvent) { event ->
         when (event) {
             is HomeUiEvent.ShowSnackBar -> onShowSnackBar(event.message)
+            is HomeUiEvent.NavigateToCardNews -> navigateToHomeCardNews(event.imgUrl)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -37,7 +37,6 @@ import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
 import com.unifest.android.core.designsystem.theme.BoothLocation
-import com.unifest.android.core.designsystem.theme.Content10
 import com.unifest.android.core.designsystem.theme.Content6
 import com.unifest.android.core.designsystem.theme.Title2
 import com.unifest.android.core.designsystem.theme.Title3

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/HomeScreen.kt
@@ -37,6 +37,7 @@ import com.unifest.android.core.common.ObserveAsEvents
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.designsystem.component.UnifestOutlinedButton
 import com.unifest.android.core.designsystem.theme.BoothLocation
+import com.unifest.android.core.designsystem.theme.Content10
 import com.unifest.android.core.designsystem.theme.Content6
 import com.unifest.android.core.designsystem.theme.Title2
 import com.unifest.android.core.designsystem.theme.Title3
@@ -51,6 +52,7 @@ import com.unifest.android.feature.home.component.Calendar
 import com.unifest.android.feature.home.component.FestivalScheduleItem
 import com.unifest.android.feature.home.component.IncomingFestivalCard
 import com.unifest.android.feature.home.component.StarImageDialog
+import com.unifest.android.feature.home.component.TipComponent
 import com.unifest.android.feature.home.preview.HomePreviewParameterProvider
 import com.unifest.android.feature.home.viewmodel.HomeUiAction
 import com.unifest.android.feature.home.viewmodel.HomeUiEvent
@@ -216,7 +218,14 @@ internal fun HomeContent(
         }
 
         if (isGacheonUniv) {
-
+            item {
+                TipComponent(
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp)
+                        .padding(top = 24.dp, bottom = 35.dp),
+                    tipMessage = "",
+                )
+            }
         } else {
             item {
                 UnifestOutlinedButton(

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
@@ -99,6 +99,7 @@ internal fun Calendar(
         Column(
             modifier = Modifier.background(MaterialTheme.colorScheme.surface),
         ) {
+            Spacer(modifier = Modifier.height(16.dp))
             val monthState = rememberCalendarState(
                 startMonth = startMonth,
                 endMonth = endMonth,

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
@@ -84,7 +84,7 @@ internal fun Calendar(
     onDateSelected: (LocalDate) -> Unit,
     adjacentMonths: Long = 500,
     allFestivals: ImmutableList<FestivalModel>,
-    isWeekMode: Boolean = false,
+    isWeekMode: Boolean = true,
     onClickWeekMode: () -> Unit,
 ) {
     val currentDate = remember { LocalDate.now() }
@@ -118,7 +118,11 @@ internal fun Calendar(
                 weekState = weekState,
             )
 
-            CalendarHeader(daysOfWeek = daysOfWeek.toImmutableList())
+            CalendarHeader(
+                isWeekMode = isWeekMode,
+                selectedDate = selectedDate,
+                daysOfWeek = daysOfWeek.toImmutableList(),
+            )
             AnimatedVisibility(visible = !isWeekMode) {
                 HorizontalCalendar(
                     state = monthState,
@@ -154,10 +158,13 @@ internal fun Calendar(
                 )
             }
 
-            ModeToggleButton(
-                isWeekMode = isWeekMode,
-                onModeChange = { onClickWeekMode() },
-            )
+            // 주간 모드 토글 버튼 (가천대 비활성화)
+            if (false) {
+                ModeToggleButton(
+                    isWeekMode = isWeekMode,
+                    onModeChange = { onClickWeekMode() },
+                )
+            }
         }
     }
 }
@@ -333,7 +340,11 @@ private fun ColorCircleWithText(color: Color, text: String) {
 }
 
 @Composable
-private fun CalendarHeader(daysOfWeek: ImmutableList<DayOfWeek>) {
+private fun CalendarHeader(
+    isWeekMode: Boolean,
+    selectedDate: LocalDate,
+    daysOfWeek: ImmutableList<DayOfWeek>,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth(),
@@ -342,7 +353,11 @@ private fun CalendarHeader(daysOfWeek: ImmutableList<DayOfWeek>) {
             Text(
                 text = dayOfWeek.displayText(),
                 modifier = Modifier.weight(1f),
-                color = MaterialTheme.colorScheme.onSurface,
+                color = if (isWeekMode && dayOfWeek == selectedDate.dayOfWeek) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
                 textAlign = TextAlign.Center,
                 style = Content6,
             )
@@ -424,7 +439,7 @@ private fun CalendarPreview() {
             selectedDate = LocalDate.now(),
             onDateSelected = {},
             allFestivals = persistentListOf(),
-            isWeekMode = false,
+            isWeekMode = true,
             onClickWeekMode = {},
         )
     }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
@@ -1,0 +1,93 @@
+package com.unifest.android.feature.home.component
+
+import android.R.attr.contentDescription
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.R as designR
+import com.unifest.android.core.designsystem.component.NetworkImage
+import com.unifest.android.core.designsystem.theme.Content10
+import com.unifest.android.core.designsystem.theme.Title2
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.core.model.CardNewsModel
+import com.unifest.android.feature.home.R
+import com.unifest.android.feature.home.clickable
+
+@Composable
+fun HomeCardNews(
+    modifier: Modifier = Modifier,
+    cardNewsList: List<CardNewsModel>,
+    onCardNewClick: (CardNewsModel) -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    Column {
+        Text(
+            modifier = Modifier.padding(horizontal = 20.dp),
+            text = stringResource(id = R.string.home_gacheon_festival_news),
+            style = Title2,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(modifier = Modifier.height(7.dp))
+        Text(
+            modifier = Modifier.padding(horizontal = 20.dp),
+            text = stringResource(id = R.string.home_gacheon_festival_news_message),
+            style = Content10,
+            color = MaterialTheme.colorScheme.onSecondary,
+        )
+        Spacer(modifier = Modifier.height(18.dp))
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .scrollable(scrollState, orientation = Orientation.Horizontal),
+        ) {
+            Spacer(modifier = Modifier.width(20.dp))
+            cardNewsList.forEach { cardNews ->
+                NetworkImage(
+                    modifier = Modifier
+                        .size(204.dp)
+                        .clip(RoundedCornerShape(7.dp))
+                        .clickable { onCardNewClick(cardNews) },
+                    imgUrl = cardNews.coverImgUrl,
+                    contentDescription = "",
+                    placeholder = painterResource(id = designR.drawable.item_placeholder),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Spacer(modifier = Modifier.width(20.dp))
+        }
+    }
+}
+
+
+@ComponentPreview
+@Composable
+private fun HomeCardNewsPreview() {
+    UnifestTheme {
+        HomeCardNews(
+            cardNewsList = listOf(
+                CardNewsModel(),
+                CardNewsModel(),
+            ),
+            onCardNewClick = {},
+        )
+    }
+}

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
@@ -1,7 +1,5 @@
 package com.unifest.android.feature.home.component
 
-import android.R.attr.contentDescription
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
@@ -23,7 +21,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.unifest.android.core.designsystem.ComponentPreview
-import com.unifest.android.core.designsystem.R as designR
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content10
 import com.unifest.android.core.designsystem.theme.Title2
@@ -31,6 +28,7 @@ import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.core.model.CardNewsModel
 import com.unifest.android.feature.home.R
 import com.unifest.android.feature.home.clickable
+import com.unifest.android.core.designsystem.R as designR
 
 @Composable
 fun HomeCardNews(
@@ -76,7 +74,6 @@ fun HomeCardNews(
         }
     }
 }
-
 
 @ComponentPreview
 @Composable

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
@@ -1,7 +1,6 @@
 package com.unifest.android.feature.home.component
 
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -55,7 +54,7 @@ fun HomeCardNews(
         Row(
             modifier = modifier
                 .fillMaxWidth()
-                .scrollable(scrollState, orientation = Orientation.Horizontal),
+                .horizontalScroll(state = scrollState),
         ) {
             Spacer(modifier = Modifier.width(20.dp))
             cardNewsList.forEach { cardNews ->

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
@@ -1,10 +1,9 @@
 package com.unifest.android.feature.home.component
 
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -14,7 +13,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalWindowInfo
 import coil.compose.AsyncImage
@@ -22,7 +24,6 @@ import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.theme.UnifestTheme
 import kotlin.math.absoluteValue
 
-// https://developer.android.com/develop/ui/compose/touch-input/pointer-input/multi-touch?hl=ko
 @Composable
 internal fun OriginalCardNews(
     modifier: Modifier = Modifier,
@@ -36,22 +37,52 @@ internal fun OriginalCardNews(
     var scale by remember { mutableFloatStateOf(1f) }
     var offset by remember { mutableStateOf(Offset.Zero) }
 
-    val state = rememberTransformableState { zoomChange, offsetChange, _ ->
-        scale = (zoomChange * scale).coerceAtLeast(minimumValue = 1f)
-        val maxOffsetX = (((imageWidth * scale) - screenWidth) / 2)
-        val maxOffsetY = (((imageHeight * scale) - screenHeight) / 2).absoluteValue
-        offset = if (scale == 1f) {
-            Offset.Zero
-        } else {
-            Offset(
-                x = (offset.x + offsetChange.x * scale).coerceIn(-maxOffsetX, maxOffsetX),
-                y = (offset.y + offsetChange.y * scale).coerceIn(-maxOffsetY, maxOffsetY),
+    val scaledWidth by remember(imageWidth, scale) { derivedStateOf { imageWidth * scale } }
+    val scaledHeight by remember(imageHeight, scale) { derivedStateOf { imageHeight * scale } }
+    val imageRect by remember(
+        scaledWidth,
+        scaledHeight,
+        offset,
+    ) {
+        derivedStateOf {
+            Rect(
+                offset = Offset(
+                    x = ((screenWidth - scaledWidth) / 2f + offset.x).coerceAtLeast(0f),
+                    y = ((screenHeight - scaledHeight) / 2f + offset.y).coerceAtLeast(0f),
+                ),
+                size = Size(scaledWidth, scaledHeight),
             )
         }
     }
 
     Box(
-        modifier = modifier,
+        modifier = modifier
+            .pointerInput(Unit) {
+                detectTransformGestures { centroid, offestChange, zoomChange, _ ->
+                    if (!imageRect.contains(centroid)) return@detectTransformGestures
+                    // 줌 적용
+                    val newScale = (scale * zoomChange).coerceAtLeast(minimumValue = 1f)
+                    scale = newScale
+
+                    // 드래그 적용
+                    val maxOffsetX = ((scaledWidth - screenWidth) / 2f).absoluteValue
+                    val maxOffsetY = ((scaledHeight - screenHeight) / 2f).absoluteValue
+                    offset = if (scale == 1f) {
+                        Offset.Zero
+                    } else {
+                        Offset(
+                            x = (offset.x + offestChange.x).coerceIn(
+                                -maxOffsetX,
+                                maxOffsetX,
+                            ),
+                            y = (offset.y + offestChange.y).coerceIn(
+                                -maxOffsetY,
+                                maxOffsetY,
+                            ),
+                        )
+                    }
+                }
+            },
     ) {
         AsyncImage(
             modifier = Modifier
@@ -61,8 +92,6 @@ internal fun OriginalCardNews(
                     translationX = offset.x,
                     translationY = offset.y,
                 )
-                .transformable(state = state)
-                .fillMaxWidth()
                 .align(Alignment.Center)
                 .onGloballyPositioned { layoutCoordinates ->
                     imageWidth = layoutCoordinates.size.width

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
@@ -38,7 +38,7 @@ internal fun OriginalCardNews(
 
     val state = rememberTransformableState { zoomChange, offsetChange, _ ->
         scale = (zoomChange * scale).coerceAtLeast(minimumValue = 1f)
-        val maxOffsetX = (((imageWidth * scale) - screenWidth) / 2).absoluteValue
+        val maxOffsetX = (((imageWidth * scale) - screenWidth) / 2)
         val maxOffsetY = (((imageHeight * scale) - screenHeight) / 2).absoluteValue
         offset = if (scale == 1f) {
             Offset.Zero

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/OriginalCardNews.kt
@@ -1,0 +1,91 @@
+package com.unifest.android.feature.home.component
+
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalWindowInfo
+import coil.compose.AsyncImage
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import kotlin.math.absoluteValue
+
+// https://developer.android.com/develop/ui/compose/touch-input/pointer-input/multi-touch?hl=ko
+@Composable
+internal fun OriginalCardNews(
+    modifier: Modifier = Modifier,
+    screenWidth: Int,
+    screenHeight: Int,
+    imageUrl: String,
+) {
+    var imageWidth by remember { mutableIntStateOf(0) }
+    var imageHeight by remember { mutableIntStateOf(0) }
+
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    val state = rememberTransformableState { zoomChange, offsetChange, _ ->
+        scale = (zoomChange * scale).coerceAtLeast(minimumValue = 1f)
+        val maxOffsetX = (((imageWidth * scale) - screenWidth) / 2).absoluteValue
+        val maxOffsetY = (((imageHeight * scale) - screenHeight) / 2).absoluteValue
+        offset = if (scale == 1f) {
+            Offset.Zero
+        } else {
+            Offset(
+                x = (offset.x + offsetChange.x * scale).coerceIn(-maxOffsetX, maxOffsetX),
+                y = (offset.y + offsetChange.y * scale).coerceIn(-maxOffsetY, maxOffsetY),
+            )
+        }
+    }
+
+    Box(
+        modifier = modifier,
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y,
+                )
+                .transformable(state = state)
+                .fillMaxWidth()
+                .align(Alignment.Center)
+                .onGloballyPositioned { layoutCoordinates ->
+                    imageWidth = layoutCoordinates.size.width
+                    imageHeight = layoutCoordinates.size.height
+                },
+            model = imageUrl,
+            contentDescription = "",
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun OriginalCardNewsPreview() {
+    UnifestTheme {
+        val screenWidth = LocalWindowInfo.current.containerSize.width
+        val screenHeight = LocalWindowInfo.current.containerSize.height
+
+        OriginalCardNews(
+            modifier = Modifier,
+            screenWidth = screenWidth,
+            screenHeight = screenHeight,
+            imageUrl = "",
+        )
+    }
+}

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/TipComponent.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/TipComponent.kt
@@ -32,14 +32,12 @@ fun TipComponent(
     darkTheme: Boolean = isSystemInDarkTheme(),
     tipMessage: String,
 ) {
-
     Row(
         modifier = modifier
             .fillMaxWidth()
             .height(44.dp)
             .background(
-                color =
-                    if (darkTheme) DarkPrimary50 else LightGrey100,
+                color = if (darkTheme) DarkPrimary50 else LightGrey100,
                 shape = RoundedCornerShape(7.dp),
             )
             .then(
@@ -61,7 +59,7 @@ fun TipComponent(
         Text(
             text = tipMessage,
             style = Content10,
-            color = if(darkTheme) LightPrimary500 else LightGrey800,
+            color = if (darkTheme) LightPrimary500 else LightGrey800,
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/TipComponent.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/TipComponent.kt
@@ -1,0 +1,77 @@
+package com.unifest.android.feature.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.unifest.android.core.designsystem.ComponentPreview
+import com.unifest.android.core.designsystem.theme.DarkPrimary50
+import com.unifest.android.core.designsystem.theme.LightGrey100
+import com.unifest.android.core.designsystem.theme.LightGrey800
+import com.unifest.android.core.designsystem.theme.LightPrimary500
+import com.unifest.android.core.designsystem.theme.Content10
+import com.unifest.android.core.designsystem.theme.Title3
+import com.unifest.android.core.designsystem.theme.UnifestTheme
+import com.unifest.android.feature.home.R
+
+@Composable
+fun TipComponent(
+    modifier: Modifier = Modifier,
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    tipMessage: String,
+) {
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .background(
+                color =
+                    if (darkTheme) DarkPrimary50 else LightGrey100,
+                shape = RoundedCornerShape(7.dp),
+            )
+            .then(
+                if (darkTheme) Modifier.border(
+                    width = 1.dp,
+                    color = LightPrimary500,
+                    shape = RoundedCornerShape(7.dp),
+                ) else Modifier,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(modifier = Modifier.width(15.dp))
+        Text(
+            text = stringResource(R.string.home_tip_text),
+            style = Title3,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = tipMessage,
+            style = Content10,
+            color = if(darkTheme) LightPrimary500 else LightGrey800,
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun TipComponentPreview() {
+    UnifestTheme {
+        TipComponent(
+            tipMessage = "웨이팅 기능으로 부스 원격 줄서기를 할 수 있어요.",
+        )
+    }
+}

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
@@ -5,10 +5,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import androidx.navigation.navOptions
+import androidx.navigation.toRoute
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.navigation.MainTabRoute
 import com.unifest.android.core.navigation.Route
+import com.unifest.android.feature.home.HomeCardNewsRoute
 import com.unifest.android.feature.home.HomeRoute
 
 fun NavController.navigateToHome(navOptions: NavOptions) {
@@ -33,7 +34,11 @@ fun NavGraphBuilder.homeNavGraph(
             navigateToHomeCardNews = navigateToHomeCardNews,
         )
     }
-    composable<Route.HomeCardNews> {
-
+    composable<Route.HomeCardNews> { navBackStackEntry ->
+        val imageUrl = navBackStackEntry.toRoute<Route.HomeCardNews>().imgUrl
+        HomeCardNewsRoute(
+            popBackStack = popBackStack,
+            imageUrl = imageUrl,
+        )
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/navigation/HomeNavigation.kt
@@ -5,17 +5,24 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import com.unifest.android.core.common.UiText
 import com.unifest.android.core.navigation.MainTabRoute
+import com.unifest.android.core.navigation.Route
 import com.unifest.android.feature.home.HomeRoute
 
 fun NavController.navigateToHome(navOptions: NavOptions) {
     navigate(MainTabRoute.Home, navOptions)
 }
 
+fun NavController.navigateToHomeCardNews(imgUrl: String) {
+    navigate(Route.HomeCardNews(imgUrl))
+}
+
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
+    navigateToHomeCardNews: (String) -> Unit,
     onShowSnackBar: (UiText) -> Unit,
 ) {
     composable<MainTabRoute.Home> {
@@ -23,6 +30,10 @@ fun NavGraphBuilder.homeNavGraph(
             padding = padding,
             popBackStack = popBackStack,
             onShowSnackBar = onShowSnackBar,
+            navigateToHomeCardNews = navigateToHomeCardNews,
         )
+    }
+    composable<Route.HomeCardNews> {
+
     }
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/preview/HomePreviewParameterProvider.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/preview/HomePreviewParameterProvider.kt
@@ -1,6 +1,7 @@
 package com.unifest.android.feature.home.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.unifest.android.core.model.CardNewsModel
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.feature.home.viewmodel.HomeUiState
@@ -65,6 +66,14 @@ internal class HomePreviewParameterProvider : PreviewParameterProvider<HomeUiSta
                     "2024-04-23",
                     126.957f,
                     37.460f,
+                ),
+            ),
+            cardNews = persistentListOf(
+                CardNewsModel(
+                    coverImgUrl = "https://example.com/image1.jpg",
+                ),
+                CardNewsModel(
+                    coverImgUrl = "https://example.com/image2.jpg",
                 ),
             ),
         ),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiAction.kt
@@ -1,5 +1,6 @@
 package com.unifest.android.feature.home.viewmodel
 
+import com.unifest.android.core.model.CardNewsModel
 import java.time.LocalDate
 
 sealed interface HomeUiAction {
@@ -9,4 +10,5 @@ sealed interface HomeUiAction {
     data class OnStarImageClick(val scheduleIndex: Int, val starIndex: Int) : HomeUiAction
     data object OnStarImageDialogDismiss : HomeUiAction
     data object OnClickWeekMode : HomeUiAction
+    data class OnCardNewsClick(val selectedCardNews: CardNewsModel) : HomeUiAction
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiEvent.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiEvent.kt
@@ -4,4 +4,5 @@ import com.unifest.android.core.common.UiText
 
 sealed interface HomeUiEvent {
     data class ShowSnackBar(val message: UiText) : HomeUiEvent
+    data class NavigateToCardNews(val imgUrl: String) : HomeUiEvent
 }

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -24,5 +24,11 @@ data class HomeUiState(
     val isDataReady: Boolean = true,
     val isStarImageDialogVisible: Boolean = false,
     val selectedStar: StarInfoModel? = null,
-    val cardNews: ImmutableList<CardNewsModel> = persistentListOf(),
+    val cardNews: ImmutableList<CardNewsModel> = persistentListOf(
+        // 더미데이터
+        CardNewsModel(
+            coverImgUrl = "https://cdn.pixabay.com/photo/2025/07/22/22/21/iceberg-9729316_1280.jpg",
+            originalUrl = "https://cdn.pixabay.com/photo/2025/07/22/22/21/iceberg-9729316_1280.jpg"
+        )
+    ),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -19,7 +19,7 @@ data class HomeUiState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val isStarImageClicked: ImmutableList<ImmutableList<Boolean>> = persistentListOf(persistentListOf()),
-    val isWeekMode: Boolean = false,
+    val isWeekMode: Boolean = true,
     val isDataReady: Boolean = true,
     val isStarImageDialogVisible: Boolean = false,
     val selectedStar: StarInfoModel? = null,

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -28,7 +28,7 @@ data class HomeUiState(
         // 더미데이터
         CardNewsModel(
             coverImgUrl = "https://cdn.pixabay.com/photo/2025/07/22/22/21/iceberg-9729316_1280.jpg",
-            originalUrl = "https://cdn.pixabay.com/photo/2025/07/22/22/21/iceberg-9729316_1280.jpg"
-        )
+            originalUrl = "https://cdn.pixabay.com/photo/2025/07/22/22/21/iceberg-9729316_1280.jpg",
+        ),
     ),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeUiState.kt
@@ -1,6 +1,7 @@
 package com.unifest.android.feature.home.viewmodel
 
 import androidx.compose.foundation.text.input.TextFieldState
+import com.unifest.android.core.model.CardNewsModel
 import com.unifest.android.core.model.FestivalModel
 import com.unifest.android.core.model.FestivalTodayModel
 import com.unifest.android.core.model.StarInfoModel
@@ -23,4 +24,5 @@ data class HomeUiState(
     val isDataReady: Boolean = true,
     val isStarImageDialogVisible: Boolean = false,
     val selectedStar: StarInfoModel? = null,
+    val cardNews: ImmutableList<CardNewsModel> = persistentListOf(),
 )

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/viewmodel/HomeViewModel.kt
@@ -49,6 +49,7 @@ class HomeViewModel @Inject constructor(
             is HomeUiAction.OnStarImageClick -> showStarImageDialog(action.scheduleIndex, action.starIndex)
             is HomeUiAction.OnStarImageDialogDismiss -> hideStarImageDialog()
             is HomeUiAction.OnClickWeekMode -> setWeekMode(!_uiState.value.isWeekMode)
+            is HomeUiAction.OnCardNewsClick -> navigateToCardNews(action.selectedCardNews.originalUrl)
         }
     }
 
@@ -168,6 +169,12 @@ class HomeViewModel @Inject constructor(
     private fun setWeekMode(flag: Boolean) {
         _uiState.update {
             it.copy(isWeekMode = flag)
+        }
+    }
+
+    private fun navigateToCardNews(imgUrl: String) {
+        viewModelScope.launch {
+            _uiEvent.send(HomeUiEvent.NavigateToCardNews(imgUrl))
         }
     }
 }

--- a/feature/home/src/main/res/drawable/ic_close_24.xml
+++ b/feature/home/src/main/res/drawable/ic_close_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="28" android:viewportWidth="28" android:width="24dp">
+      
+    <path android:fillColor="#00000000" android:pathData="M2,26L14,14M26,2L14,14M14,14L2,2M14,14L26,26" android:strokeColor="#BABABF" android:strokeWidth="3"/>
+    
+</vector>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -9,5 +9,6 @@
     <string name="home_add_interest_festival_saved_failed_message">관심 축제로 저장을 실패했습니다.</string>
     <string name='home_empty_festival_text'>축제 일정 없음</string>
     <string name="home_empty_festival_schedule_description_text">오늘은 축제가 열리는 학교가 없어요</string>
+    <string name="home_tip_text">Tip!</string>
 
 </resources>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -10,5 +10,7 @@
     <string name='home_empty_festival_text'>축제 일정 없음</string>
     <string name="home_empty_festival_schedule_description_text">오늘은 축제가 열리는 학교가 없어요</string>
     <string name="home_tip_text">Tip!</string>
+    <string name="home_gacheon_festival_news">가천대 축제 소식</string>
+    <string name="home_gacheon_festival_news_message">가천대 축제 소식 및 정보를 카드뉴스로 확인해보세요</string>
 
 </resources>

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
@@ -70,6 +70,10 @@ internal class MainNavController(
         navigate(MainTab.WAITING)
     }
 
+    fun navigateToHomeCardNews(imgUrl: String) {
+        navController.navigate(Route.HomeCardNews(imgUrl))
+    }
+
     private fun popBackStack() {
         navController.popBackStack()
     }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainNavController.kt
@@ -16,6 +16,7 @@ import com.unifest.android.feature.booth.navigation.navigateToBooth
 import com.unifest.android.feature.booth_detail.navigation.navigateToBoothDetail
 import com.unifest.android.feature.booth_detail.navigation.navigateToBoothDetailLocation
 import com.unifest.android.feature.home.navigation.navigateToHome
+import com.unifest.android.feature.home.navigation.navigateToHomeCardNews
 import com.unifest.android.feature.liked_booth.navigation.navigateToLikedBooth
 import com.unifest.android.feature.map.navigation.navigateToMap
 import com.unifest.android.feature.menu.navigation.navigateToMenu
@@ -71,7 +72,7 @@ internal class MainNavController(
     }
 
     fun navigateToHomeCardNews(imgUrl: String) {
-        navController.navigate(Route.HomeCardNews(imgUrl))
+        navController.navigateToHomeCardNews(imgUrl)
     }
 
     private fun popBackStack() {

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainScreen.kt
@@ -92,6 +92,7 @@ internal fun MainScreen(
             homeNavGraph(
                 padding = innerPadding,
                 popBackStack = navigator::popBackStackIfNotMap,
+                navigateToHomeCardNews = navigator::navigateToHomeCardNews,
                 onShowSnackBar = onShowSnackBar,
             )
             mapNavGraph(


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #391 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 홈 UI
가천대 요구사항에 맞춘 UI를 적용했습니다. 혹여 이후 가천대를 제외한 곳에서 서비스할 경우를 대비해서 `isGacheonUniv` 라는 불리언값을 선언해 새로운 UI 와 기존 UI 를 구분했습니다.
> 현재 하드코딩으로 적어놨지만, Release 모드로 가천대에만 타겟하는 방법이 있을까요 ??

- 카드뉴스 확대
확대된 원본 이미지를 띄우는 Screen 을 구현했습니다. 논의한 내용처럼 컴포넌트보단 Screen으로 구현하고, 새로운 모듈을 만들기보단 home 모듈에 새로운 스크린을 추가하는 방향으로 구현했습니다.
상세 내용은 하단 **추가 설명** 탭에서 작성하겠습니다.

참고: https://developer.android.com/develop/ui/compose/touch-input/pointer-input/multi-touch?hl=ko

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 홈 UI |<img src="https://github.com/user-attachments/assets/e5936b99-9d84-4823-99e9-adf60c8bd05d" width="300" />| 기능 설명 |<video src="https://github.com/user-attachments/assets/02ff462b-2695-44df-aa83-9c08dc181609" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

**주요 코드**
```kotlin
internal fun OriginalCardNews(
    ...
    val state = rememberTransformableState { zoomChange, offsetChange, _ ->

        // 기본값인 1f 사이즈보다 작아지지 않도록 설정
        scale = (zoomChange * scale).coerceAtLeast(minimumValue = 1f)

        // 이미지의 최대 오프셋 범위 설정
        // 오프셋의 기준값 -> 컴포넌트 중앙
        // 이동 가능한 offset 범위 => (이미지 크기 * 확대정도 - 스크린 크기) / 2
        val maxOffsetX = (((imageWidth * scale) - screenWidth) / 2)
        val maxOffsetY = (((imageHeight * scale) - screenHeight) / 2).absoluteValue

        // 기본 값일 경우 중앙 고정
        offset = if (scale == 1f) {
            Offset.Zero
        } else {
            Offset(
                x = (offset.x + offsetChange.x * scale).coerceIn(-maxOffsetX, maxOffsetX),
                y = (offset.y + offsetChange.y * scale).coerceIn(-maxOffsetY, maxOffsetY),
            )
        }
    }
    ...
```



```kotlin
    AsyncImage(
        modifier = Modifier
            .graphicsLayer(
                scaleX = scale,
                scaleY = scale,
                translationX = offset.x,
                translationY = offset.y,
            )
            .transformable(state = state)
            .fillMaxWidth()
            .align(Alignment.Center)
            .onGloballyPositioned { layoutCoordinates ->

                // 오프셋 계산용 이미지 크기 측정
                imageWidth = layoutCoordinates.size.width
                imageHeight = layoutCoordinates.size.height
            },
    )
}
```


- 이슈 1. 하단 네비게이션바가 사라지면서 화면이 버벅거리는 현상

https://github.com/user-attachments/assets/f3456419-7601-4cba-a7af-048bbb1666e0

하단 네비게이션이 `visible = false` 가 되며 `AnimatedVisibility` 때문에 느리게 사라지면서 fillMaxSize() 로 인한 Height 가 변화함 (네비게이션 사이즈만큼 Height가 변화)
-> 이미지의 포지션이 변화함.

- 그래서 다른 NavGraph에서 구현한 방법인 UnifestScaffold 의 innerPadding 값을 전달하는 대신, padding 값을 전달받지 않고 쌩으로 스크린에 systemBarsPadding() 을 적용했습니다.

- 이슈 2. 카드뉴스 이미지 Recomposition 횟수

리컴포지션이 많이 일어나는 컴포저블이기 때문에,
Landscapist 의 CoilImage 를 썼을 때 리컴포지션이 과도하게 일어나서 일반 AsyncImage 로 구현했습니다.

(한 번 확대, 한 번 드래그 했을 떄 리컴포지션 횟수)
<img width="946" height="516" alt="image" src="https://github.com/user-attachments/assets/f39f1b14-6f26-403b-946c-6569caf9c261" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면에 카드뉴스(이미지) 리스트 및 전체보기 기능이 추가되었습니다.
  * 카드뉴스 이미지는 클릭 시 확대/축소 및 이동이 가능한 전체 화면 뷰어로 표시됩니다.
  * 홈 화면 상단에 팁 메시지 컴포넌트가 추가되었습니다.

* **UI 개선**
  * 캘린더가 기본적으로 주간 모드로 표시되도록 변경되었습니다.
  * 홈 화면의 UI 구성이 조건에 따라 다르게 표시되도록 개선되었습니다.

* **내비게이션**
  * 카드뉴스 전체보기 화면으로 이동하는 내비게이션이 추가되었습니다.

* **기타**
  * 이미지 로딩 성능 향상을 위해 Coil 라이브러리가 도입되었습니다.
  * 새로운 아이콘 및 문자열 리소스가 추가되었습니다.
  * 새로운 텍스트 스타일(Content10)이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->