### PR TITLE
chore: 필요 없는 코드 제거 및 하드 코딩 문자열 stringResource 추출 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.unifest.android.firebase)
     alias(libs.plugins.unifest.android.hilt)
     alias(libs.plugins.google.secrets)
-    alias(libs.plugins.android.application)
     alias(libs.plugins.baselineprofile)
 }
 

--- a/app/src/main/kotlin/com/unifest/android/service/UnifestFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/unifest/android/service/UnifestFirebaseMessagingService.kt
@@ -33,7 +33,7 @@ class UnifestFirebaseMessagingService : FirebaseMessagingService() {
 
         // Activity 의 onNewIntent 가 호출되기 위해선 해당 flag 들이 필요함
         val intent = Intent(this, MainActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             putExtra("notification", true)
         }
 

--- a/core/navigation/src/main/kotlin/com/unifest/android/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/kotlin/com/unifest/android/core/navigation/RouteModel.kt
@@ -6,10 +6,10 @@ sealed interface Route {
     @Serializable
     data object BoothDetail {
         @Serializable
-        data class BoothDetail(val boothId: Long) : Route
+        data class Detail(val boothId: Long) : Route
 
         @Serializable
-        data object BoothLocation : Route
+        data object Location : Route
     }
 
     @Serializable

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/navigation/BoothDetailNavigation.kt
@@ -15,11 +15,11 @@ import com.unifest.android.feature.booth_detail.viewmodel.BoothDetailViewModel
 fun NavController.navigateToBoothDetail(
     boothId: Long,
 ) {
-    navigate(Route.BoothDetail.BoothDetail(boothId))
+    navigate(Route.BoothDetail.Detail(boothId))
 }
 
 fun NavController.navigateToBoothDetailLocation() {
-    navigate(Route.BoothDetail.BoothLocation)
+    navigate(Route.BoothDetail.Location)
 }
 
 fun NavGraphBuilder.boothDetailNavGraph(
@@ -30,9 +30,9 @@ fun NavGraphBuilder.boothDetailNavGraph(
     getBackStackViewModel: @Composable (NavBackStackEntry) -> BoothDetailViewModel,
 ) {
     navigation<Route.BoothDetail>(
-        startDestination = Route.BoothDetail.BoothDetail::class,
+        startDestination = Route.BoothDetail.Detail::class,
     ) {
-        composable<Route.BoothDetail.BoothDetail> { navBackStackEntry ->
+        composable<Route.BoothDetail.Detail> { navBackStackEntry ->
             BoothDetailRoute(
                 padding = padding,
                 popBackStack = popBackStack,
@@ -41,7 +41,7 @@ fun NavGraphBuilder.boothDetailNavGraph(
                 viewModel = getBackStackViewModel(navBackStackEntry),
             )
         }
-        composable<Route.BoothDetail.BoothLocation> { navBackStackEntry ->
+        composable<Route.BoothDetail.Location> { navBackStackEntry ->
             BoothDetailLocationRoute(
                 popBackStack = popBackStack,
                 viewModel = getBackStackViewModel(navBackStackEntry),

--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/viewmodel/BoothDetailViewModel.kt
@@ -38,7 +38,7 @@ class BoothDetailViewModel @Inject constructor(
     private val waitingRepository: WaitingRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel(), ErrorHandlerActions {
-    private val boothId = savedStateHandle.toRoute<Route.BoothDetail.BoothDetail>().boothId
+    private val boothId = savedStateHandle.toRoute<Route.BoothDetail.Detail>().boothId
 
     private val _uiState = MutableStateFlow(BoothDetailUiState())
     val uiState: StateFlow<BoothDetailUiState> = _uiState.asStateFlow()

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainActivity.kt
@@ -18,7 +18,6 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            val navigator: MainNavController = rememberMainNavController()
             val systemUiController = rememberExSystemUiController()
             val isDarkTheme = isSystemInDarkTheme()
 
@@ -33,9 +32,7 @@ class MainActivity : ComponentActivity() {
             }
 
             UnifestTheme {
-                MainScreen(
-                    navigator = navigator,
-                )
+                MainScreen()
             }
         }
     }

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainTab.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/MainTab.kt
@@ -1,37 +1,40 @@
 package com.unifest.android.feature.main
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import com.unifest.android.core.navigation.MainTabRoute
 import com.unifest.android.core.navigation.Route
 
 internal enum class MainTab(
-    val iconResId: Int,
-    val selectedIconResId: Int,
+    @DrawableRes val iconResId: Int,
+    @DrawableRes val selectedIconResId: Int,
+    @StringRes val labelResId: Int,
     internal val contentDescription: String,
-    val label: String,
     val route: MainTabRoute,
 ) {
     HOME(
         iconResId = R.drawable.ic_home,
         selectedIconResId = R.drawable.ic_selected_home,
+        labelResId = R.string.home_label,
         contentDescription = "Home Icon",
-        label = "홈",
         route = MainTabRoute.Home,
     ),
     WAITING(
         iconResId = R.drawable.ic_waiting,
         selectedIconResId = R.drawable.ic_selected_waiting,
+        labelResId = R.string.waiting_label,
         contentDescription = "Waiting Icon",
-        label = "웨이팅",
         route = MainTabRoute.Waiting,
     ),
     MAP(
         iconResId = R.drawable.ic_map,
         selectedIconResId = R.drawable.ic_selected_map,
+        labelResId = R.string.map_label,
         contentDescription = "Map Icon",
-        label = "지도",
         route = MainTabRoute.Map,
     ),
+
 //    STAMP(
 //        iconResId = R.drawable.ic_stamp,
 //        selectedIconResId = R.drawable.ic_selected_stamp,
@@ -39,19 +42,18 @@ internal enum class MainTab(
 //        label = "스탬프",
 //        route = MainTabRoute.Stamp,
 //    ),
-
     BOOTH(
         iconResId = R.drawable.ic_booth,
         selectedIconResId = R.drawable.ic_selected_booth,
+        labelResId = R.string.booth_label,
         contentDescription = "Booth Icon",
-        label = "부스",
         route = MainTabRoute.Booth,
     ),
     MENU(
         iconResId = R.drawable.ic_menu,
         selectedIconResId = R.drawable.ic_selected_menu,
+        labelResId = R.string.menu_label,
         contentDescription = "Menu Icon",
-        label = "메뉴",
         route = MainTabRoute.Menu,
     ),
     ;

--- a/feature/main/src/main/kotlin/com/unifest/android/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/kotlin/com/unifest/android/feature/main/component/MainBottomBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
@@ -107,7 +108,7 @@ private fun RowScope.MainBottomBarItem(
             )
             Spacer(modifier = Modifier.height(5.dp))
             Text(
-                text = tab.label,
+                text = stringResource(tab.labelResId),
                 color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSecondary,
                 fontWeight = if (selected) FontWeight.SemiBold
                 else FontWeight.Normal,

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="home_label">홈</string>
+    <string name="waiting_label">웨이팅</string>
+    <string name="map_label">지도</string>
+    <string name="booth_label">부스</string>
+    <string name="menu_label">메뉴</string>
+</resources>

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashActivity.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/SplashActivity.kt
@@ -70,9 +70,7 @@ class SplashActivity : ComponentActivity() {
                                 activity = this@SplashActivity,
                                 withFinish = true,
                             ) {
-                                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                                    Intent.FLAG_ACTIVITY_SINGLE_TOP
+                                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                                 intent.extras?.let { putExtras(it) }
                                 this
                             }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/Project-Unifest/unifest-android/issues/409

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 필요 없는 코드(중복 plugin 적용, 필요없는 intent Flag...etx)제거 및 하드 코딩 문자열 stringResource 추출 

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 사소한 작업이라 확인 후 문제 없음 바로 merge 하면 될 것 같습니다 ^>^ 
- Booth라는 표현이 계속 중복되어 BoothDetail Route 하위 라우트에는 Booth prefix를 제거하였습니다.
- Booth 모듈쪽 코드를 다시 한번 확인해봤는데, 초기로딩 방식이 제가 [리팩토링을 하려고 했던 방식](https://github.com/Project-Unifest/unifest-android/issues/295#issue-2951057877)으로 되어있군여+_+. 숙원사업이었는데 감사합니다. 다른 화면들의 viewModel의 init 방식들도 이러한 지연 초기화 방식으로 전환해보면 좋을 것 같네요 ㅎㅎ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 알림을 탭했을 때 앱 전환 동작을 개선하여 기존 화면을 적절히 재사용하도록 수정했습니다.
  - 스플래시 이후 메인 화면 이동 시 중복 실행을 방지하고 자연스러운 전환이 이루어지도록 수정했습니다.
- 스타일
  - 하단 탭 라벨 표기를 문자열 리소스로 일원화하여 일관된 텍스트 표시를 제공합니다.
  - 홈/웨이팅/지도/부스/메뉴 라벨 문자열을 추가해 탭 표시 텍스트를 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->