### PR TITLE
[refactor] 축제가 없을 때에서 달력에 기본 패딩 적용

### DIFF
--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
@@ -420,22 +420,21 @@ private fun Day(
                 style = Title5,
             )
         }
-        if (festivalCount > 0) {
-            val festivalDotColor = when (festivalCount) {
-                1 -> if (isSystemInDarkTheme()) DarkBlueGreen else LightBlueGreen
-                2 -> if (isSystemInDarkTheme()) DarkOrange else LightOrange
-                else -> if (isSystemInDarkTheme()) DarkRed else LightRed
-            }
-            Box(
-                modifier = Modifier
-                    .size(9.dp)
-                    .clip(CircleShape)
-                    .background(festivalDotColor)
-                    .align(Alignment.CenterHorizontally)
-                    .padding(bottom = 24.dp),
-            )
-            Spacer(modifier = Modifier.height(12.dp))
+        val festivalDotColor = when (festivalCount) {
+            0 -> Color.Transparent
+            1 -> if (isSystemInDarkTheme()) DarkBlueGreen else LightBlueGreen
+            2 -> if (isSystemInDarkTheme()) DarkOrange else LightOrange
+            else -> if (isSystemInDarkTheme()) DarkRed else LightRed
         }
+        Box(
+            modifier = Modifier
+                .size(9.dp)
+                .clip(CircleShape)
+                .background(festivalDotColor)
+                .align(Alignment.CenterHorizontally)
+                .padding(bottom = 24.dp),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
     }
 }
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #421

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 홈 화면에서 축제가 없을 경우에도 날짜 하단에 패딩을 추가했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|
|:--:|:--:|
| 적용 후 이미지 |<img width="321" height="121" alt="image" src="https://github.com/user-attachments/assets/f5722a28-a8db-4486-8bb5-03058f2bd79a" />| 


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- PM 님 요청으로 수정했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 캘린더 날짜 셀에서 축제가 없는 날에 간격이 달라 보이던 문제를 해결하여 모든 날짜의 하단 정렬과 간격을 일관되게 유지합니다. 스크롤 시 셀 흔들림이 줄어 가독성이 향상됩니다.
* **스타일**
  * 축제 지표(점) 표시 로직을 개선했습니다. 축제가 없을 때는 투명 점을 사용해 레이아웃 안정성을 확보하고, 1/2/3+ 개수에 따른 색상과 다크 모드 대응은 그대로 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->