### PR TITLE
fix: 가천대 축제 대비 2차 QA 반영 및 앱 버전 업데이트(1.6.2 -> 1.6.3)

### DIFF
--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
@@ -60,31 +60,29 @@ fun TransformableImage(
             .pointerInput(Unit) {
                 detectTransformGestures { centroid, offestChange, zoomChange, _ ->
                     if (!imageRect.contains(centroid)) return@detectTransformGestures
-                    
                     // 줌 변경 시 핀치 포인트를 기준으로 확대/축소
                     if (zoomChange != 1f) {
                         val newScale = (scale * zoomChange).coerceAtLeast(minimumValue = 1f)
-                        
                         // 현재 이미지의 실제 위치 (중심점 + 오프셋)
                         val currentImageCenter = Offset(
                             x = screenWidth / 2f + offset.x,
-                            y = screenHeight / 2f + offset.y
+                            y = screenHeight / 2f + offset.y,
                         )
-                        
+
                         // 핀치 포인트에서 현재 이미지 중심까지의 거리
                         val relativePoint = centroid - currentImageCenter
-                        
+
                         // 스케일 변화에 따른 오프셋 조정 (핀치 포인트가 고정되도록)
                         val scaleChange = newScale / scale
                         val newOffsetX = offset.x + relativePoint.x * (1f - scaleChange)
                         val newOffsetY = offset.y + relativePoint.y * (1f - scaleChange)
-                        
+
                         scale = newScale
-                        
+
                         // 경계 체크 및 오프셋 제한
                         val maxOffsetX = ((imageWidth * newScale - screenWidth) / 2f).coerceAtLeast(0f)
                         val maxOffsetY = ((imageHeight * newScale - screenHeight) / 2f).coerceAtLeast(0f)
-                        
+
                         offset = if (newScale == 1f) {
                             Offset.Companion.Zero
                         } else {

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
@@ -60,9 +60,40 @@ fun TransformableImage(
             .pointerInput(Unit) {
                 detectTransformGestures { centroid, offestChange, zoomChange, _ ->
                     if (!imageRect.contains(centroid)) return@detectTransformGestures
-                    // 줌 적용
-                    val newScale = (scale * zoomChange).coerceAtLeast(minimumValue = 1f)
-                    scale = newScale
+                    
+                    // 줌 변경 시 핀치 포인트를 기준으로 확대/축소
+                    if (zoomChange != 1f) {
+                        val newScale = (scale * zoomChange).coerceAtLeast(minimumValue = 1f)
+                        
+                        // 현재 이미지의 실제 위치 (중심점 + 오프셋)
+                        val currentImageCenter = Offset(
+                            x = screenWidth / 2f + offset.x,
+                            y = screenHeight / 2f + offset.y
+                        )
+                        
+                        // 핀치 포인트에서 현재 이미지 중심까지의 거리
+                        val relativePoint = centroid - currentImageCenter
+                        
+                        // 스케일 변화에 따른 오프셋 조정 (핀치 포인트가 고정되도록)
+                        val scaleChange = newScale / scale
+                        val newOffsetX = offset.x + relativePoint.x * (1f - scaleChange)
+                        val newOffsetY = offset.y + relativePoint.y * (1f - scaleChange)
+                        
+                        scale = newScale
+                        
+                        // 경계 체크 및 오프셋 제한
+                        val maxOffsetX = ((imageWidth * newScale - screenWidth) / 2f).coerceAtLeast(0f)
+                        val maxOffsetY = ((imageHeight * newScale - screenHeight) / 2f).coerceAtLeast(0f)
+                        
+                        offset = if (newScale == 1f) {
+                            Offset.Companion.Zero
+                        } else {
+                            Offset(
+                                x = newOffsetX.coerceIn(-maxOffsetX, maxOffsetX),
+                                y = newOffsetY.coerceIn(-maxOffsetY, maxOffsetY),
+                            )
+                        }
+                    }
 
                     // 드래그 적용
                     val maxOffsetX = ((scaledWidth - screenWidth) / 2f).absoluteValue

--- a/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
+++ b/core/designsystem/src/main/kotlin/com/unifest/android/core/designsystem/component/TransformableImage.kt
@@ -74,8 +74,10 @@ fun TransformableImage(
 
                         // 스케일 변화에 따른 오프셋 조정 (핀치 포인트가 고정되도록)
                         val scaleChange = newScale / scale
-                        val newOffsetX = offset.x + relativePoint.x * (1f - scaleChange)
-                        val newOffsetY = offset.y + relativePoint.y * (1f - scaleChange)
+                        var newOffsetX = offset.x + relativePoint.x * (1f - scaleChange)
+                        var newOffsetY = offset.y + relativePoint.y * (1f - scaleChange)
+                        newOffsetX += offestChange.x
+                        newOffsetY += offestChange.y
 
                         scale = newScale
 
@@ -84,13 +86,16 @@ fun TransformableImage(
                         val maxOffsetY = ((imageHeight * newScale - screenHeight) / 2f).coerceAtLeast(0f)
 
                         offset = if (newScale == 1f) {
-                            Offset.Companion.Zero
+                            Offset.Zero
                         } else {
                             Offset(
                                 x = newOffsetX.coerceIn(-maxOffsetX, maxOffsetX),
                                 y = newOffsetY.coerceIn(-maxOffsetY, maxOffsetY),
                             )
                         }
+
+                        // 스케일 변경 후 드래그 처리로 이동
+                        return@detectTransformGestures
                     }
 
                     // 드래그 적용

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -26,17 +25,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.unifest.android.core.designsystem.ComponentPreview
-import com.unifest.android.core.designsystem.R as designR
 import com.unifest.android.core.designsystem.component.NetworkImage
 import com.unifest.android.core.designsystem.theme.Content2
 import com.unifest.android.core.designsystem.theme.Title2
@@ -45,6 +41,7 @@ import com.unifest.android.core.designsystem.theme.UnifestTheme
 import com.unifest.android.feature.map.R
 import com.unifest.android.feature.map.model.BoothMapModel
 import com.unifest.android.feature.map.viewmodel.MapUiAction
+import com.unifest.android.core.designsystem.R as designR
 
 @Composable
 internal fun BoothItem(

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
@@ -87,9 +87,9 @@ internal fun BoothItem(
                 Column(
                     modifier = Modifier.padding(start = 15.dp),
                 ) {
-                   Box(
-                        modifier = Modifier.heightIn(min = titleTextHeight)
-                   ) {
+                    Box(
+                        modifier = Modifier.height(titleTextHeight),
+                    ) {
                         Text(
                             text = boothInfo.name,
                             color = MaterialTheme.colorScheme.onBackground,
@@ -108,7 +108,7 @@ internal fun BoothItem(
                     Text(
                         text = boothInfo.description,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.heightIn(min = descriptionTextHeight),
+                        modifier = Modifier.height(descriptionTextHeight),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         style = Content2,

--- a/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
+++ b/feature/map/src/main/kotlin/com/unifest/android/feature/map/component/BoothItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -25,12 +26,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.unifest.android.core.designsystem.ComponentPreview
 import com.unifest.android.core.designsystem.R as designR
 import com.unifest.android.core.designsystem.component.NetworkImage
@@ -51,9 +55,13 @@ internal fun BoothItem(
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
-    val textStyle = Content2
-    val textHeight = remember(textStyle) {
+    val descriptionTextStyle = Content2
+    val descriptionTextHeight = remember(descriptionTextStyle) {
         with(density) { Content2.fontSize.toDp() * 2 }
+    }
+    val titleTextStyle = Title2
+    val titleTextHeight = remember(titleTextStyle) {
+        with(density) { Title2.fontSize.toDp() * 2 }
     }
 
     Card(
@@ -79,16 +87,28 @@ internal fun BoothItem(
                 Column(
                     modifier = Modifier.padding(start = 15.dp),
                 ) {
-                    Text(
-                        text = boothInfo.name,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        style = Title2,
-                    )
+                   Box(
+                        modifier = Modifier.heightIn(min = titleTextHeight)
+                   ) {
+                        Text(
+                            text = boothInfo.name,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            style = Title2,
+                            modifier = Modifier.align(Alignment.CenterStart),
+                            maxLines = 2,
+                            autoSize = TextAutoSize.StepBased(
+                                minFontSize = 13.sp,
+                                maxFontSize = 18.sp,
+                                stepSize = 0.5.sp,
+                            ),
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                     Spacer(modifier = Modifier.height(3.dp))
                     Text(
                         text = boothInfo.description,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.heightIn(min = textHeight),
+                        modifier = Modifier.heightIn(min = descriptionTextHeight),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         style = Content2,

--- a/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/com/unifest/android/feature/menu/viewmodel/MenuViewModel.kt
@@ -168,7 +168,7 @@ class MenuViewModel @Inject constructor(
 
     override fun setNetworkErrorDialogVisible(flag: Boolean) {
         _uiState.update {
-            it.copy(isServerErrorDialogVisible = flag)
+            it.copy(isNetworkErrorDialogVisible = flag)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
 versionCode = "47"
-versionName = "1.6.2"
+versionName = "1.6.3"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.12.2"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/Project-Unifest/unifest-android/issues/437

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 확대 가능 이미지 가장자리 줌 가능하도록 기능 개선
- 지도 화면 인기 부스 아이템 최대 높이 설정
- MenuViewModel 에러 타입 수정
- 앱 버전 변경 1.6.2 -> 1.6.3

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 지도 부스 제목이 자동 크기 조절되며 최대 2줄(말줄임)로 표시되고, 설명 영역 높이가 가독성에 맞게 조정되었습니다.
* 버그 수정
  * 이미지 확대가 핀치 중심을 기준으로 동작하고 확대 시 이동 범위를 화면 내부로 제한합니다.
  * 네트워크 오류 다이얼로그 표시 상태가 올바르게 반영되도록 수정했습니다.
* 작업
  * 앱 버전을 1.6.3으로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->