### PR TITLE
fix: 주간 캘린더 뷰 축제가 없을 경우에도 패딩 값 16.dp 로 조정

### DIFF
--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/Calendar.kt
@@ -397,7 +397,7 @@ private fun Day(
                     top = 16.dp,
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = if (festivalCount > 0) 8.dp else 16.dp,
+                    bottom = 16.dp,
                 )
                 .clip(CircleShape)
                 .background(color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)


### PR DESCRIPTION
## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 홈 주간 캘린더 padding 간격 수정

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
보기 편하게 임시로 검은 색 dot 을 추가했습니다. (커밋엔 반영 X)

|Before|After|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/9900ab29-40fd-490d-9c5e-65a57abde20c" width="300" />|<img src="https://github.com/user-attachments/assets/8541b919-3f23-4bb9-898c-66e66bf9b65f" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 캘린더 상 festival 이 없다면 하단 패딩 값이 16.dp 이지만, festival 이 있으면 8.dp 라서, 저 8.dp 의 차이만큼 날짜 컴포넌트가 높이를 차지해서 동그란 원형이 일그러지는 현상을 해결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 홈 캘린더의 일자 셀 하단 여백을 16dp로 통일했습니다. 축제 표시 여부와 관계없이 동일한 간격을 유지해 셀 높이와 배치가 일정하게 보입니다. 날짜/도트 정렬이 더 균일해지고 화면 전반의 시각적 일관성이 향상됩니다. 기능 동작 변화는 없으며, 선택 상태·오늘 표시·축제 점 표시는 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->