### PR TITLE
fix: 가천대 축제 대비 관심 축제 등록 API 앱 진입시 마다 호출되도록 수정

### DIFF
--- a/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
+++ b/feature/booth-detail/src/main/kotlin/com/unifest/android/feature/booth_detail/BoothDetailScreen.kt
@@ -114,7 +114,7 @@ internal fun BoothDetailRoute(
             value = ImageLuminanceUtils.calculateLuminance(uiState.boothDetailInfo.thumbnail, context)
         }
     }.value
-    // 밝은 이미지일 때 어두운 아이콘 사용
+    // 밝은 이미지일 때 어두운 아이콘 사용 vice versa
     val shouldUseDarkIcons = imageLuminance?.isDark?.not() ?: !isDarkTheme
 
     DisposableEffect(shouldUseDarkIcons) {

--- a/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/unifest/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -165,6 +165,7 @@ class IntroViewModel @Inject constructor(
 
     private fun addLikedFestivals() {
         viewModelScope.launch {
+            // TODO 관심 축제 등록 API 호출 이후 성공시 하위 로직 태우는 방식으로 변경
             likedFestivalRepository.apply {
                 insertLikedFestivals(_uiState.value.selectedFestivals)
                 setRecentLikedFestival(_uiState.value.selectedFestivals.first())

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -94,6 +94,8 @@ class SplashViewModel @Inject constructor(
     }
 
     private suspend fun registerLikedFestival() {
+        // 현재 가천대만 서비스하므로 모든 사용자에게 등록
+        // TODO: 향후 다중 대학 서비스 시 사용자별 타게팅 로직 추가 필요
         val festivalId = if (BuildConfig.DEBUG) 1L else 15L
         likedFestivalRepository.registerLikedFestival(FestivalModel(festivalId = festivalId))
             .onSuccess {

--- a/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/unifest/android/feature/splash/viewmodel/SplashViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.unifest.android.core.common.ErrorHandlerActions
 import com.unifest.android.core.common.handleException
+import com.unifest.android.core.data.api.repository.LikedFestivalRepository
 import com.unifest.android.core.data.api.repository.MessagingRepository
 import com.unifest.android.core.data.api.repository.OnboardingRepository
 import com.unifest.android.core.data.api.repository.RemoteConfigRepository
+import com.unifest.android.core.model.FestivalModel
+import com.unifest.android.feature.splash.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -24,6 +27,7 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
     private val onboardingRepository: OnboardingRepository,
     private val messagingRepository: MessagingRepository,
+    private val likedFestivalRepository: LikedFestivalRepository,
     remoteConfigRepository: RemoteConfigRepository,
 ) : ViewModel(), ErrorHandlerActions {
     private val _uiState = MutableStateFlow(SplashUiState())
@@ -44,6 +48,8 @@ class SplashViewModel @Inject constructor(
 
     fun checkIntroCompletion() {
         viewModelScope.launch {
+            launch { registerLikedFestival() }
+
             if (onboardingRepository.checkIntroCompletion()) {
                 _uiEvent.send(SplashUiEvent.NavigateToMain)
             } else {
@@ -85,6 +91,17 @@ class SplashViewModel @Inject constructor(
             handleException(exception, this@SplashViewModel)
             false
         }
+    }
+
+    private suspend fun registerLikedFestival() {
+        val festivalId = if (BuildConfig.DEBUG) 1L else 15L
+        likedFestivalRepository.registerLikedFestival(FestivalModel(festivalId = festivalId))
+            .onSuccess {
+                Timber.d("festival registered: festivalId=$festivalId")
+            }
+            .onFailure { exception ->
+                Timber.e(exception)
+            }
     }
 
     private fun navigateToPlayStore() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "35"
 compileSdk = "35"
-versionCode = "50"
-versionName = "1.6.5"
+versionCode = "51"
+versionName = "1.6.6"
 packageName = "com.unifest.android"
 
 android-gradle-plugin = "8.12.2"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 현재 Intro 화면에서 가천대 선택이후 홈 화면 진입시, 로컬 DB엔 관심 축제로 추가되지만 /interest API를 호출하지않아, 확성기를 통한 알림을 받지 못하는 문제 발생
- 앱 진입시 splash 에서 가천대 축제를 관심 축제로 추가하여, 가천대 학생들이 확성기 알림을 받도록 수정
- Intro 화면에서 관심 축제 선택시 API를 태워도 되지만, 이미 앱을 설치한 사용자의 경우 Intro 화면에 다시 진입할 수 없으므로, 현재의 방식으로 적용

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 석준님과 테스트를 통해 확성기 알림 정상 수신되는 것 확인 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 스플래시 화면에서 앱 시작 시 선호 축제를 백그라운드로 자동 등록하도록 추가했습니다(화면 전환을 차단하지 않음).
- Documentation
  - 인트로 처리 로직에 향후 리팩터링을 위한 TODO 주석을 추가했습니다(동작 변화 없음).
- Style
  - 부스 화면 주석 문구를 사소하게 정정했습니다(동작 영향 없음).
- Chores
  - 앱 버전 업데이트: 1.6.6 (버전 코드 51).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->