### PR TITLE
fix: 웨이팅 터치 사이즈 조정, 홈 카드뉴스 이미지 비율 조정

### DIFF
--- a/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
+++ b/feature/booth/src/main/kotlin/com/unifest/android/feature/booth/BoothScreen.kt
@@ -133,6 +133,9 @@ internal fun BoothContent(
                 )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.clickable {
+                        onAction(BoothUiAction.OnWaitingCheckBoxClick)
+                    },
                 ) {
                     Icon(
                         imageVector = ImageVector.vectorResource(
@@ -140,9 +143,6 @@ internal fun BoothContent(
                         ),
                         contentDescription = "check box icon",
                         tint = Color.Unspecified,
-                        modifier = Modifier.clickable {
-                            onAction(BoothUiAction.OnWaitingCheckBoxClick)
-                        },
                     )
                     Text(
                         text = stringResource(id = R.string.waiting_availability),

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
+++ b/feature/home/src/main/kotlin/com/unifest/android/feature/home/component/HomeCardNews.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -60,11 +63,13 @@ fun HomeCardNews(
             cardNewsList.forEach { cardNews ->
                 NetworkImage(
                     modifier = Modifier
-                        .size(204.dp)
+                        .width(204.dp)
+                        .heightIn(min = 204.dp)
                         .clip(RoundedCornerShape(7.dp))
                         .clickable { onCardNewClick(cardNews) },
                     imgUrl = cardNews.thumbnailImgUrl,
                     contentDescription = "",
+                    contentScale = ContentScale.FillBounds,
                     placeholder = painterResource(id = designR.drawable.item_placeholder),
                 )
                 Spacer(modifier = Modifier.width(8.dp))

--- a/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/WaitingScreen.kt
+++ b/feature/waiting/src/main/kotlin/com/unifest/android/feature/waiting/WaitingScreen.kt
@@ -2,7 +2,6 @@ package com.unifest.android.feature.waiting
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +21,7 @@ import androidx.compose.material3.CardColors
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -36,7 +36,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skydoves.compose.effects.RememberedEffect
 import com.unifest.android.core.common.ObserveAsEvents
-import com.unifest.android.core.common.extension.clickableSingle
 import com.unifest.android.core.designsystem.component.LoadingWheel
 import com.unifest.android.core.designsystem.component.NetworkErrorDialog
 import com.unifest.android.core.designsystem.component.ServerErrorDialog
@@ -162,10 +161,11 @@ internal fun WaitingContent(
                 }
             }
         }
-        item { Spacer(modifier = Modifier.height(10.dp)) }
+        item { Spacer(modifier = Modifier.height(2.dp)) }
         item {
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
@@ -173,23 +173,26 @@ internal fun WaitingContent(
                     color = MaterialTheme.colorScheme.onBackground,
                     style = Content7,
                 )
-                Row(
-                    modifier = Modifier.clickableSingle {
+                TextButton(
+                    onClick = {
                         onWaitingUiAction(WaitingUiAction.OnRefresh)
                     },
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(id = R.string.refresh),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = Content2,
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Icon(
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_refresh),
-                        contentDescription = "refresh icon",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.refresh),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = Content2,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_refresh),
+                            contentDescription = "refresh icon",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }
@@ -223,17 +226,19 @@ internal fun WaitingContent(
                     style = WaitingNumber4,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(id = R.string.waiting_no_waiting_description),
-                    style = Content2.copy(
-                        textDecoration = TextDecoration.Underline,
-                    ),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.clickable {
+                TextButton(
+                    onClick = {
                         onWaitingUiAction(WaitingUiAction.OnLookForBoothClick)
                     },
-                )
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.waiting_no_waiting_description),
+                        style = Content2.copy(
+                            textDecoration = TextDecoration.Underline,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 웨이팅 가능여부의 터칭 영역을 Checkbox 에서 Row 로 확장했습니다.
- 웨이팅 화면에서 텍스트의 터칭 영역을 TextButton 을 사용해 확장했습니다.
- 홈 카드뉴스 화면에서 카드 뉴스의 비율을 1:1 대신 이미지 별로 적용 가능하도록 했습니다.

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|웨이팅 가능 여부|텍스트 버튼|
|:--:|:--:|
|<video src="https://github.com/user-attachments/assets/f5c631cf-f2ef-43fd-b695-80d81f41944b" width="300" />|<video src="https://github.com/user-attachments/assets/bfef946e-dae5-4c4a-bd36-63b19f71eb04" width="300" />|

|홈 카드뉴스 이전(Small Phone 기준)|홈 카드뉴스 이후(Small Phone 기준)|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/d602859f-aac1-452a-989e-6e9686fc8c30" width="300" />|<img src="https://github.com/user-attachments/assets/46bf632a-4c48-4a56-906f-81f23b4860f0" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 홈 카드뉴스 비율은 PM님께 여쭤보고 진행했습니다!
- 바로 이어 webp 변환 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 대기 체크박스의 터치 영역을 행 전체로 확대해 선택이 더 쉬워졌습니다.
  * 홈 뉴스 카드 이미지가 고정 너비·최소 높이를 사용하고 영역을 채우도록 스케일링되어 시각적 일관성이 향상되었습니다.
  * 대기 화면의 텍스트 클릭 요소를 버튼으로 교체하고 간격(10dp→2dp)을 조정해 상호작용과 레이아웃을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->