### PR TITLE
refactor: WaitingDialog isButtonEnabled remember key(phoneNumberState.text) 제거 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 ## Features
 
 ## Article
+- [[Android] 이미지의 Luminance 를 계산하는 방법](https://velog.io/@mraz3068/How-To-Know-Image-Luminance)
+- [[Compose] derivedStateOf 에 대해 잘못 알고 있던 부분](https://velog.io/@mraz3068/derivedStateOf-Misconceptions)
+- [[Android] FCM Background 에서 수신하여 진입 화면 변경 하는 법](https://velog.io/@mraz3068/Android-FCM-Background-Receive-Way)
+- [[Compose] M3 ModalBottomSheet 드래그(터치 이벤트) 막는 법](https://velog.io/@mraz3068/Compose-M3-ModalBottomSheet-Drag-Disabled)
 - [[Android] NaverMap Compose 클러스터링 구현](https://velog.io/@mraz3068/Android-NaverMap-Compose-Clurstering-Implementation)
 - [[Android] SSAID 는 debug 환경에서 달라질 수 있다!](https://velog.io/@mraz3068/Android-SSAID-Debug-Build-Variant-Issue)
 - [[Android] Type-Safe Compose Navigation 적용 - 중첩(Nested) 네비게이션 구조](https://velog.io/@mraz3068/Android-Type-Safe-Compose-Navigation-Applying-in-Nested-Navigation)
@@ -32,7 +36,9 @@
 - [[Android] Jetpack Compose 에서 Snackbar Duration 을 Custom 하는 방법](https://velog.io/@mraz3068/Android-Compose-Snackbar-Duration-Custom)
 - [[Android] TextField Keyboard 가 다시 올라오지 않는 문제 해결](https://velog.io/@mraz3068/Android-BasicTextField2-Keyboard-Does-Not-Appear-Issue)
 - [[Android] Compose BasicTextField2 적용해보기](https://velog.io/@mraz3068/Using-Android-Compose-BasicTextField2)
-
+- [유니페스의 구조는 어떻게 세웠을까?(3)](https://rogue-one.tistory.com/145)
+- [유니페스는 어떻게 협업했을까?(2)](https://rogue-one.tistory.com/144)
+- [대학 축제 지도를 펼처라! 유니페스 소개(1)](https://rogue-one.tistory.com/140)
 ## Development
 
 ### Required

--- a/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
+++ b/core/ui/src/main/kotlin/com/unifest/android/core/ui/component/WaitingDialog.kt
@@ -204,7 +204,7 @@ fun WaitingDialog(
     onPrivacyPolicyClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isButtonEnabled by remember(phoneNumberState.text, partySize, isPrivacyClicked) {
+    val isButtonEnabled by remember(partySize, isPrivacyClicked) {
         derivedStateOf {
             val phoneNumber = phoneNumberState.text.toString().replace("-", "")
             val isPhoneNumberValid = phoneNumber.matches(RegexConstants.PHONE_NUMBER)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- derivedStateOf 를 사용해야할 필요가 있나 싶지만(UiState 내에 computed property로 대체 가능), 현재 사용하고 있는 패턴을 그대로 유지하는 경우, Compose State 기반의 phoneNumberState.text는 remember의 key로 넣어주지 않아도 상태 추적이 가능하기 때문에 제거하였습니다.(전화번호 입력시 매번 WaitingDialog 의 리컴포지션 발생이 되지 않도록)
- 작성했던 블로그글들 리드미 Article 탭에 추가했습니다.

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- [[Compose] derivedStateOf 에 대해 잘못 알고 있던 부분](https://velog.io/@mraz3068/derivedStateOf-Misconceptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - README의 Article 섹션을 최신화했습니다: 새 글 7개 추가, 기존 글 3개 제거.
- 버그 수정
  - 대기 다이얼로그에서 버튼 활성화 상태 계산을 최적화해 전화번호 입력 시 반응성을 개선하고 불필요한 지연을 완화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->